### PR TITLE
fix: make Datastore.redirect? a lot more robust

### DIFF
--- a/lib/syskit/log/datastore.rb
+++ b/lib/syskit/log/datastore.rb
@@ -290,7 +290,6 @@ module Syskit::Log
                 FileUtils.mv cache_path_of(old_digest), cache_path_of(new_digest)
             end
 
-            puts "#{old_digest}: dataset identity changed to #{new_digest}"
             get(new_digest, validate: false, preload_metadata: false)
         end
     end

--- a/lib/syskit/log/datastore.rb
+++ b/lib/syskit/log/datastore.rb
@@ -100,9 +100,13 @@ module Syskit::Log
         # Test whether the file at the given path is a redirect file
         def self.redirect?(path)
             return unless path.file?
+            return unless Dataset.valid_encoded_digest?(path.basename.to_s)
 
-            YAML.safe_load(path.read).key?("to")
-        rescue Psych::SyntaxError # rubocop:disable Lint/SuppressedException
+            return false unless (to = YAML.safe_load(path.read)["to"])
+            return false unless to.respond_to?(:to_str)
+
+            Dataset.valid_encoded_digest?(to)
+        rescue Psych::SyntaxError, Psych::DisallowedClass # rubocop:disable Lint/SuppressedException
         end
 
         # Enumerate the store's datasets

--- a/lib/syskit/log/datastore/dataset.rb
+++ b/lib/syskit/log/datastore/dataset.rb
@@ -181,12 +181,19 @@ module Syskit::Log
                 digest
             end
 
+            # Validate that the given digest is a valid dataset ID
+            #
+            # See {valid_encoded_digest?} to for a true/false check
+            #
+            # @param [String]
+            # @raise [InvalidDigest]
             def self.validate_encoded_digest(digest)
                 validate_encoded_sha2(digest)
             end
 
-            # Validate that the argument looks like a valid sha2 digest encoded
-            # with {DIGEST_ENCODING_METHOD}
+            # @api private
+            #
+            # Implementation of {.validate_encoded_digest} for SHA2 hashes
             def self.validate_encoded_sha2(sha2)
                 if sha2.length != ENCODED_DIGEST_LENGTH
                     raise InvalidDigest,
@@ -200,6 +207,21 @@ module Syskit::Log
                           "Expected characters in 0-9a-zA-Z+/"
                 end
                 sha2
+            end
+
+            # Checks if the given digest is a valid dataset ID
+            #
+            # @see validate_encoded_digest
+            def self.valid_encoded_digest?(digest)
+                valid_encoded_sha2?(digest)
+            end
+
+            # @api private
+            #
+            # Implementation of {.valid_encoded_digest?} for SHA2 hashes
+            def self.valid_encoded_sha2?(sha2)
+                sha2.length == ENCODED_DIGEST_LENGTH &&
+                    /^[0-9a-f]+$/.match?(sha2)
             end
 
             # Return the path to the file containing identity metadata

--- a/test/datastore/dataset_test.rb
+++ b/test/datastore/dataset_test.rb
@@ -91,6 +91,26 @@ module Syskit::Log
                 end
             end
 
+            describe ".valid_encoded_sha2?" do
+                attr_reader :sha2
+                before do
+                    @sha2 = Digest::SHA2.hexdigest("TEST")
+                end
+                it "returns false if the string is too short" do
+                    refute Dataset.valid_encoded_sha2?(sha2[0..-2])
+                end
+                it "raises if the string is too long" do
+                    refute Dataset.valid_encoded_sha2?(sha2 + " ")
+                end
+                it "raises if the string contains invalid characters for base64" do
+                    sha2[3, 1] = "_"
+                    refute Dataset.valid_encoded_sha2?(sha2)
+                end
+                it "returns true it is valid" do
+                    assert Dataset.valid_encoded_sha2?(sha2)
+                end
+            end
+
             describe ".validate_encoded_sha2" do
                 attr_reader :sha2
                 before do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,12 +19,21 @@ module Syskit::Log
                 Roby.app.add_plugin("syskit-log", Syskit::Log::Plugin)
             end
 
+            @temp_paths = []
             super
         end
 
         def teardown
             Pocolog.logger.level = @pocolog_log_level if @pocolog_log_level
+            @temp_paths.each(&:rmtree)
             super
+        end
+
+        def make_tmppath
+            dir = Dir.mktmpdir
+            path = Pathname.new(dir)
+            @temp_paths << path
+            path
         end
 
         def logfile_pathname(*basename)


### PR DESCRIPTION
I started having compressed core directories in my datastore/core
to save space. Found out that redirect? would try to load the files
to process them using YAML and then check if there is a "to" field.

This commit greatly strenghtens redirect? to avoid this error case,
but also avoid problems with other possible edge cases.