### PR TITLE
fix: simplify error handling by normalizing pocolog files in groups

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,13 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new("test:lib") do |t|
     t.libs << "test"
     t.libs << "lib"
     t.test_files = FileList["test/**/*_test.rb"]
     t.warning = false
 end
+task "test" => "test:lib"
 
 task :default
 

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -86,46 +86,20 @@ module Syskit::Log
                 end
             end
 
-            DigestIO = Struct.new :wio, :digest do
+            # @api private
+            #
+            # An IO-looking object that computes the output's digest
+            class DigestIO < SimpleDelegator
+                attr_reader :digest
+
+                def initialize(wio, digest)
+                    super(wio)
+                    @digest = digest
+                end
+
                 def write(string)
-                    wio.write string
-                    digest.update string
-                end
-
-                def close
-                    wio.close
-                end
-
-                def flush
-                    wio.flush
-                end
-
-                def tell
-                    wio.tell
-                end
-
-                def closed?
-                    wio.closed?
-                end
-
-                def seek(pos)
-                    wio.seek(pos)
-                end
-
-                def read(count)
-                    wio.read(count)
-                end
-
-                def path
-                    wio.path
-                end
-
-                def size
-                    wio.size
-                end
-
-                def stat
-                    wio.stat
+                    super
+                    @digest.update string
                 end
             end
 

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -114,61 +114,89 @@ module Syskit::Log
                 compute_sha256: false
             )
                 output_path.mkpath
-                paths.each do |logfile_path|
-                    e, out_io = normalize_logfile(
-                        logfile_path, output_path,
-                        reporter: reporter, compute_sha256: compute_sha256
-                    )
-
-                    if e
-                        normalize_cleanup_after_error(
-                            reporter, logfile_path, out_io, index_dir
-                        )
-                        raise e
-                    end
+                index_dir.mkpath
+                logfile_groups = paths.group_by do
+                    /\.\d+\.log$/.match(_1.basename.to_s).pre_match
                 end
 
-                # Now write the indexes
-                index_dir.mkpath
-                out_files.each_value do |output|
-                    block_stream = output.create_block_stream
-                    raw_stream_info = Pocolog::IndexBuilderStreamInfo.new(output.stream_block_pos, output.index_map)
-                    stream_info = Pocolog.create_index_from_raw_info(block_stream, [raw_stream_info])
-                    index_path = Pocolog::Logfiles.default_index_filename(output.path, index_dir: index_dir)
-                    File.open(index_path, "w") do |io|
-                        Pocolog::Format::Current.write_index(io, block_stream.io, stream_info)
-                    end
+                result = logfile_groups.values.map do |files|
+                    normalize_logfile_group(
+                        files,
+                        output_path: output_path, index_dir: index_dir,
+                        reporter: reporter, compute_sha256: compute_sha256
+                    )
                 end
 
                 if compute_sha256
+                    result.inject { |a, b| a.merge(b) }
+                else
+                    result.flatten
+                end
+            end
+
+            def normalize_logfile_group(
+                files,
+                output_path:,
+                index_dir:, reporter: Pocolog::CLI::NullReporter.new,
+                compute_sha256: false
+            )
+                files.each do |logfile_path|
+                    normalize_logfile(
+                        logfile_path, output_path,
+                        reporter: reporter, compute_sha256: compute_sha256
+                    )
+                rescue Exception # rubocop:disable Lint/RescueException
+                    reporter.warn(
+                        "normalize: exception caught while processing #{logfile_path}"
+                    )
+                    raise
+                end
+
+                write_pending_pocolog_indexes(index_dir)
+
+                if compute_sha256
                     result = {}
-                    out_files.each_value.map { |output| result[output.path] = output.digest }
+                    out_files.each_value.map do |output|
+                        result[output.path] = output.digest
+                    end
                     result
                 else
                     out_files.each_value.map(&:path)
                 end
+            rescue Exception # rubocop:disable Lint/RescueException
+                reporter.warn(
+                    "normalize: deleting #{out_files.size} output files and their indexes"
+                )
+                out_files.each_value { _1.path.unlink }
+                raise
             ensure
                 out_files.each_value(&:close)
+                out_files.clear
             end
 
-            def normalize_cleanup_after_error(reporter, logfile_path, out_io, index_dir)
-                reporter.warn(
-                    "normalize: exception caught while processing "\
-                    "#{logfile_path}, deleting #{out_io.size} output files: "\
-                    "#{out_io.map(&:path).sort.join(', ')}"
-                )
-                out_io.each do |output|
-                    out_files.delete(output.path)
-                    output.close
-
-                    Pathname.new(output.path).unlink
-                    index_path = Pathname.new(
-                        Pocolog::Logfiles.default_index_filename(
-                            output.path, index_dir: index_dir
-                        )
+            def write_pending_pocolog_indexes(index_dir)
+                indexes = []
+                # Now write the indexes
+                out_files.each_value do |output|
+                    block_stream = output.create_block_stream
+                    raw_stream_info = Pocolog::IndexBuilderStreamInfo.new(
+                        output.stream_block_pos, output.index_map
                     )
-                    index_path.unlink if index_path.exist?
+                    stream_info = Pocolog.create_index_from_raw_info(
+                        block_stream, [raw_stream_info]
+                    )
+                    index_path = Pocolog::Logfiles.default_index_filename(
+                        output.path, index_dir: index_dir
+                    )
+                    indexes << index_path
+                    File.open(index_path, "w") do |io|
+                        Pocolog::Format::Current
+                            .write_index(io, block_stream.io, stream_info)
+                    end
                 end
+            rescue Exception # rubocop:disable Lint/RescueException
+                indexes.map { _1.unlink if _1.exist? }
+                raise
             end
 
             NormalizationState =
@@ -213,22 +241,18 @@ module Syskit::Log
                 in_io = logfile_path.open
                 in_block_stream =
                     normalize_logfile_init(logfile_path, in_io, reporter: reporter)
-                return nil, [] unless in_block_stream
+                return unless in_block_stream
 
                 reporter_offset = reporter.current
                 normalize_logfile_process_block_stream(
                     output_path, state, in_block_stream,
                     reporter: reporter, compute_sha256: compute_sha256
                 )
-                [nil, state.out_io_streams]
             rescue Pocolog::InvalidBlockFound => e
                 reporter.warn "#{logfile_path.basename} looks truncated or contains "\
                               "garbage (#{e.message}), stopping processing but keeping "\
                               "the samples processed so far"
                 reporter.current = in_io.size + reporter_offset
-                [nil, state.out_io_streams]
-            rescue StandardError => e
-                [e, (state.out_io_streams || [])]
             ensure
                 state.out_io_streams.each(&:flush)
                 in_block_stream&.close

--- a/test/datastore/normalize_test.rb
+++ b/test/datastore/normalize_test.rb
@@ -166,7 +166,7 @@ module Syskit::Log
                             .with("file0.0.log does not seem to be a valid pocolog file, skipping")
                             .once
                     reporter.should_receive(:current=).with(17).once
-                    assert_equal [nil, []], normalize.normalize_logfile(
+                    assert_nil normalize.normalize_logfile(
                         logfile_pathname("file0.0.log"),
                         logfile_pathname("normalized"), reporter: reporter
                     )
@@ -176,12 +176,11 @@ module Syskit::Log
                         create_logfile_stream "stream0",
                                               metadata: Hash["rock_task_name" => "task0", "rock_task_object_name" => "port"]
                         write_logfile_sample base_time + 3, base_time + 30, 3
+                        write_logfile_sample base_time + 4, base_time + 40, 4
                     end
                     file0_path = logfile_pathname("file0.0.log")
                     file0_size = file0_path.stat.size
-                    logfile_pathname("file0.0.log").open("a") do |io|
-                        io.truncate(file0_size - 1)
-                    end
+                    logfile_pathname("file0.0.log").truncate(file0_size - 1)
                     logfile_pathname("normalized").mkpath
                     reporter = flexmock(Pocolog::CLI::NullReporter.new)
                     flexmock(reporter).should_receive(:current).and_return(10)
@@ -189,12 +188,16 @@ module Syskit::Log
                             .with(/^file0.0.log looks truncated/)
                             .once
                     reporter.should_receive(:current=).with(10 + file0_size - 1).once
-                    error, ios = normalize.normalize_logfile(
+                    normalize.normalize_logfile(
                         logfile_pathname("file0.0.log"),
                         logfile_pathname("normalized"), reporter: reporter
                     )
-                    assert_nil error
-                    assert_equal logfile_pathname("normalized", "task0::port.0.log"), ios[0].path
+                    stream = open_logfile_stream(
+                        logfile_pathname("normalized", "task0::port.0.log"),
+                        "task0.port"
+                    )
+                    assert_equal [[base_time + 3, base_time + 30, 3]],
+                                 stream.samples.to_a
                 end
             end
         end


### PR DESCRIPTION
This pull request uses the (valid) assumption that a data stream,
once encountered, will always be logged by the same logger in the
same "file group" (that is, the same sequence of rotated logs).

So, if we process all log files of a group `NAME.SEQ.log` together,
recovering from an error is simply removing all output files created
during the processing. This removes the need for a log of bookkeeping.

On top of #19 