### PR TITLE
fix: add digest to a dataset's metadata hash for consistency

### DIFF
--- a/lib/syskit/log/datastore/dataset.rb
+++ b/lib/syskit/log/datastore/dataset.rb
@@ -562,6 +562,8 @@ module Syskit::Log
                 @metadata = loaded.inject({}) do |h, (k, v)|
                     h.merge!(k => v.to_set)
                 end
+                @metadata.merge!("digest" => Set[digest]) if digest
+                @metadata
             end
 
             # Write this dataset's metadata to disk

--- a/test/cli/datastore_test.rb
+++ b/test/cli/datastore_test.rb
@@ -417,6 +417,7 @@ a0ea first
   array_test:
   - a
   - b
+  digest: a0ea
   test: 2
   timestamp: #{@a0ea_time.tv_sec}
                     EOF
@@ -425,6 +426,7 @@ a0fa <no description>
   array_test:
   - c
   - d
+  digest: a0fa
   test: 1
   timestamp: #{@a0fa_time.tv_sec}
                     EOF
@@ -621,7 +623,8 @@ a0fa <no description>
                         out, _err = capture_io do
                             call_cli("metadata", "--store", datastore_path.to_s, "--get", silent: false)
                         end
-                        assert_equal "a0ea test=a,b timestamp=12345\na0fa test=b timestamp=12346\n", out
+                        assert_equal "a0ea digest=a0ea test=a,b timestamp=12345\n"\
+                                     "a0fa digest=a0fa test=b timestamp=12346\n", out
                     end
                     it "displays the short digest by default" do
                         flexmock(Syskit::Log::Datastore).new_instances.should_receive(:short_digest)
@@ -629,14 +632,16 @@ a0fa <no description>
                         out, _err = capture_io do
                             call_cli("metadata", "--store", datastore_path.to_s, "--get", silent: false)
                         end
-                        assert_equal "a0e test=a timestamp=12345\na0f test=b timestamp=12346\n", out
+                        assert_equal "a0e digest=a0ea test=a timestamp=12345\n"\
+                                     "a0f digest=a0fa test=b timestamp=12346\n", out
                     end
                     it "displays the long digest if --long-digest is given" do
                         flexmock(datastore).should_receive(:short_digest).never
                         out, _err = capture_io do
                             call_cli("metadata", "--store", datastore_path.to_s, "--get", "--long-digest", silent: false)
                         end
-                        assert_equal "a0ea test=a timestamp=12345\na0fa test=b timestamp=12346\n", out
+                        assert_equal "a0ea digest=a0ea test=a timestamp=12345\n"\
+                                     "a0fa digest=a0fa test=b timestamp=12346\n", out
                     end
                     it "lists the requested metadata of the matching datasets" do
                         call_cli("metadata", "--store", datastore_path.to_s, "a0ea", "--set", "test=a,b", "debug=true", silent: false)

--- a/test/datastore/import_test.rb
+++ b/test/datastore/import_test.rb
@@ -169,7 +169,8 @@ module Syskit::Log
                     end
                     dataset = import.import([logfile_pathname])
                     assert_equal({ "roby:app_name" => Set["test"],
-                                   "timestamp" => Set[0] }, dataset.metadata)
+                                   "timestamp" => Set[0],
+                                   "digest" => Set[dataset.digest] }, dataset.metadata)
                     assert_equal({ "roby:app_name" => Set["test"],
                                    "timestamp" => Set[0] },
                                  Dataset.new(dataset.dataset_path).metadata)
@@ -184,8 +185,10 @@ module Syskit::Log
                         imported = import.import([logfile_pathname])
                     end
                     assert_match(/failed to load Roby metadata/, err)
-                    assert_equal({ "timestamp" => Set[0] }, imported.metadata)
-                    assert_equal({ "timestamp" => Set[0] }, Dataset.new(imported.dataset_path).metadata)
+                    assert_equal({ "timestamp" => Set[0], "digest" => Set[imported.digest] },
+                                 imported.metadata)
+                    assert_equal({ "timestamp" => Set[0] },
+                                 Dataset.new(imported.dataset_path).metadata)
                 end
                 it "rebuilds a valid Roby index" do
                     FileUtils.cp roby_log_path("model_registration"),


### PR DESCRIPTION
It allows to use any method that looks for metadata to search for a digest, instead of having
the digest being a separate "search key".