### PR TITLE
feat: lazy loaded streams in replay

### DIFF
--- a/lib/syskit/log/lazy_data_stream.rb
+++ b/lib/syskit/log/lazy_data_stream.rb
@@ -33,7 +33,7 @@ module Syskit::Log
         # The stream metadata
         #
         # @return [Hash]
-        attr_reader :metadata
+        attr_accessor :metadata
 
         # The size, in samples, of the stream
         #

--- a/lib/syskit/log/replay_manager.rb
+++ b/lib/syskit/log/replay_manager.rb
@@ -82,9 +82,9 @@ module Syskit::Log
         #
         # @param [Deployment] deployment_task the task to register
         # @return [void]
-        def register(deployment_task, streams)
+        def register(deployment_task)
             new_streams = []
-            streams.each do |s|
+            deployment_task.model.each_stream_mapping.each do |s, _|
                 if (pocolog = @stream_syskit_to_pocolog[s])
                     @dispatch_info[pocolog].deployments << deployment_task
                 else

--- a/lib/syskit/log/roby_sql_index/accessors.rb
+++ b/lib/syskit/log/roby_sql_index/accessors.rb
@@ -622,16 +622,19 @@ module Syskit
                         @global_stream = global_stream
                     end
 
-                    def stream
+                    def syskit_eager_load
+                        return @pocolog_stream if @pocolog_stream
+
                         s = @global_stream.syskit_eager_load
                         start, stop = @task.interval_lg
                         return unless start
 
-                        s.from_logical_time(start).to_logical_time(stop)
+                        @pocolog_stream =
+                            s.from_logical_time(start).to_logical_time(stop)
                     end
 
                     def samples
-                        stream.samples
+                        syskit_eager_load.samples
                     end
                 end
 

--- a/lib/syskit/log/streams.rb
+++ b/lib/syskit/log/streams.rb
@@ -21,6 +21,13 @@ module Syskit::Log
             streams
         end
 
+        # Load the set of streams available from a file
+        def self.from_dataset(dataset)
+            streams = new
+            streams.add_dataset(dataset)
+            streams
+        end
+
         # The list of streams that are available
         #
         # @return [Array<LazyDataStream>]

--- a/test/replay_manager_test.rb
+++ b/test/replay_manager_test.rb
@@ -17,224 +17,251 @@ module Syskit::Log
                                 "rock_stream_type" => "port" }
                 )
             end
-            @streams = Streams.from_dir(logfile_pathname)
-                              .find_task_by_name("task")
-            @port_stream = streams.find_port_by_name("out")
             @task_m = Syskit::TaskContext.new_submodel do
                 output_port "out", double_t
             end
 
             plan = Roby::ExecutablePlan.new
             @subject = ReplayManager.new(plan.execution_engine)
-
-            @deployment_m = Syskit::Log::Deployment
-                            .for_streams(streams, model: task_m, name: "task")
         end
 
-        describe "#register" do
-            it "registers the stream-to-deployment mapping" do
-                deployment_task = deployment_m.new
-                subject.register(deployment_task)
-                other_task = deployment_m.new
-                subject.register(other_task)
-                assert_equal [deployment_task, other_task],
-                             subject.find_deployments_of_stream(port_stream)
-            end
-            it "deregisters the stream if no deployment tasks are still using it" do
-                deployment_task = deployment_m.new
-                subject.register(deployment_task)
-                assert_equal [deployment_task],
-                             subject.find_deployments_of_stream(port_stream)
-            end
-            it "aligns the streams that are managed by the deployment task" do
-                deployment_task = deployment_m.new
-                flexmock(subject.stream_aligner)
-                    .should_receive(:add_streams)
-                    .with(streams.find_port_by_name("out"))
-                    .once
-                subject.register(deployment_task)
-            end
-            it "does not realign the streams that are already in-use by another deployment" do
-                deployment_task = deployment_m.new
-                subject.register(deployment_task)
+        def self.common_behavior # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+            describe "#register" do
+                it "registers the stream-to-deployment mapping" do
+                    deployment_task = deployment_m.new
+                    subject.register(deployment_task)
+                    other_task = deployment_m.new
+                    subject.register(other_task)
+                    assert_equal [deployment_task, other_task],
+                                 subject.find_deployments_of_stream(port_stream)
+                end
+                it "deregisters the stream if no deployment tasks are still using it" do
+                    deployment_task = deployment_m.new
+                    subject.register(deployment_task)
+                    assert_equal [deployment_task],
+                                 subject.find_deployments_of_stream(port_stream)
+                end
+                it "aligns the streams that are managed by the deployment task" do
+                    deployment_task = deployment_m.new
+                    flexmock(subject.stream_aligner)
+                        .should_receive(:add_streams)
+                        .with(resolve_pocolog_stream(streams.find_port_by_name("out")))
+                        .once
+                    subject.register(deployment_task)
+                end
+                it "does not realign the streams that are already in-use by another deployment" do
+                    deployment_task = deployment_m.new
+                    subject.register(deployment_task)
 
-                flexmock(subject.stream_aligner)
-                    .should_receive(:add_streams)
-                    .with_no_args
-                    .once.pass_thru
-                other_task = deployment_m.new
-                subject.register(other_task)
+                    flexmock(subject.stream_aligner)
+                        .should_receive(:add_streams)
+                        .with_no_args
+                        .once.pass_thru
+                    other_task = deployment_m.new
+                    subject.register(other_task)
+                end
+            end
+
+            describe "#deregister" do
+                it "removes the streams that are managed by the deployment task from the aligner" do
+                    deployment_task = deployment_m.new
+                    subject.register(deployment_task)
+                    flexmock(subject.stream_aligner)
+                        .should_receive(:remove_streams)
+                        .with(resolve_pocolog_stream(streams.find_port_by_name("out")))
+                        .once
+                    subject.deregister(deployment_task)
+                end
+                it "does not deregister streams that are still in use by another deployment" do
+                    deployment_task = deployment_m.new
+                    subject.register(deployment_task)
+                    other_task = deployment_m.new
+                    subject.register(other_task)
+
+                    flexmock(subject.stream_aligner)
+                        .should_receive(:remove_streams)
+                        .with().once.pass_thru
+                    subject.deregister(other_task)
+                end
+                it "deregisters the deployment task from the targets for the stream" do
+                    deployment_task = deployment_m.new
+                    subject.register(deployment_task)
+                    other_task = deployment_m.new
+                    subject.register(other_task)
+                    subject.deregister(other_task)
+                    assert_equal [deployment_task],
+                                 subject.find_deployments_of_stream(port_stream)
+                end
+                it "deregisters the stream if no deployment tasks are still using it" do
+                    deployment_task = deployment_m.new
+                    subject.register(deployment_task)
+                    subject.deregister(deployment_task)
+                    assert_equal [], subject.find_deployments_of_stream(port_stream)
+                end
+            end
+
+            describe "realtime replay" do
+                it "raises RuntimeError in #start if it is already running" do
+                    subject.start
+                    assert_raises(RuntimeError) { subject.start }
+                end
+
+                it "is running after a call to #start" do
+                    subject.start
+                    assert subject.running?
+                end
+
+                it "raises RuntimeError if #stop is called while it is not running" do
+                    assert_raises(RuntimeError) { subject.stop }
+                end
+
+                it "is not running after a call to #stop" do
+                    subject.start
+                    subject.stop
+                    assert !subject.running?
+                end
+
+                it "installs a handler that calls #process_in_realtime once in each cycle" do
+                    subject.execution_engine.execute_one_cycle
+                    subject.start(replay_speed: 10)
+                    flexmock(subject).should_receive(:process_in_realtime).twice.with(10)
+                    subject.execution_engine.execute_one_cycle
+                    subject.execution_engine.execute_one_cycle
+                    subject.stop
+                    subject.execution_engine.execute_one_cycle
+                end
+            end
+
+            describe "#process_in_realtime" do
+                before do
+                    double_t = Roby.app.default_loader.registry.get "/double"
+
+                    create_logfile "test.0.log" do
+                        stream0 = create_logfile_stream(
+                            "/port0",
+                            type: double_t,
+                            metadata: { "rock_task_name" => "task",
+                                        "rock_task_object_name" => "out",
+                                        "rock_stream_type" => "port" }
+                        )
+                        stream0.write Time.at(0), Time.at(0), 0
+                        stream0.write Time.at(0), Time.at(1), 1
+                        stream0.write Time.at(0), Time.at(2), 2
+                    end
+
+                    streams = Streams.from_dir(logfile_pathname)
+                                     .find_task_by_name("task")
+                    task_m = Syskit::TaskContext.new_submodel do
+                        output_port "out", double_t
+                    end
+
+                    deployment_m = Syskit::Log::Deployment
+                                   .for_streams(streams, model: task_m, name: "task")
+                    deployment = deployment_m.new(process_name: "test", on: "pocolog")
+                    plan.add_permanent_task(deployment)
+                    expect_execution { deployment.start! }
+                        .to { emit deployment.ready_event }
+
+                    @subject = plan.execution_engine.pocolog_replay_manager
+                    subject.reset_replay_base_times
+                    flexmock(subject)
+                end
+
+                it "plays as many samples as required to match real and expected logical time" do
+                    subject.should_receive(:sleep)
+                    realtime = subject.base_real_time
+                    flexmock(Time).should_receive(:now).and_return { realtime }
+                    subject.should_receive(:dispatch).once.with(0, Time.at(0))
+                           .and_return { realtime += 1 }
+                    subject.should_receive(:dispatch).once.with(0, Time.at(1))
+                           .and_return { realtime += 1 }
+                    subject.process_in_realtime(1, limit_real_time: realtime + 1.1)
+                end
+
+                it "applies the speed to the sample limit" do
+                    subject.should_receive(:sleep)
+                    realtime = subject.base_real_time
+                    flexmock(Time).should_receive(:now).and_return { realtime }
+                    subject.should_receive(:dispatch).once.with(0, Time.at(0))
+                           .and_return { realtime += 1 }
+                    subject.should_receive(:dispatch).once.with(0, Time.at(1))
+                           .and_return { realtime += 1 }
+                    subject.process_in_realtime(2, limit_real_time: realtime + 0.55)
+                end
+
+                it "returns true if there are samples left to play" do
+                    subject.should_receive(:sleep)
+                    realtime = subject.base_real_time
+                    flexmock(Time).should_receive(:now).and_return { realtime }
+                    assert subject.process_in_realtime(1, limit_real_time: realtime + 1.1)
+                end
+
+                it "returns false on eof" do
+                    subject.should_receive(:sleep)
+                    realtime = subject.base_real_time
+                    flexmock(Time).should_receive(:now).and_return { realtime }
+                    assert !subject.process_in_realtime(1, limit_real_time: realtime + 2.1)
+                end
+
+                it "sleeps between samples" do
+                    realtime = subject.base_real_time
+                    flexmock(Time).should_receive(:now).and_return { realtime }
+                    subject.should_receive(:dispatch).with(0, Time.at(0)).globally.ordered
+                    subject.should_receive(:sleep).explicitly.with(1).once.globally.ordered
+                           .and_return { realtime += 1 }
+                    subject.should_receive(:dispatch).with(0, Time.at(1)).globally.ordered
+                           .and_return { realtime += 1 }
+                    subject.process_in_realtime(1, limit_real_time: realtime + 1.1)
+                end
+
+                it "applies the replay speed to the sleeping times" do
+                    realtime = subject.base_real_time
+                    flexmock(Time).should_receive(:now).and_return { realtime }
+                    subject.should_receive(:dispatch)
+                    subject.should_receive(:sleep).explicitly.with(0.5).once.globally.ordered
+                           .and_return { realtime += 0.5 }
+                    subject.process_in_realtime(2, limit_real_time: realtime + 0.55)
+                end
+
+                it "does not sleep if the required sleep time is below MIN_TIME_DIFF_TO_SLEEP" do
+                    realtime = subject.base_real_time
+                    flexmock(Time).should_receive(:now).and_return { realtime }
+                    subject.should_receive(:dispatch)
+                    subject.should_receive(:sleep).explicitly.never
+                    subject.process_in_realtime(1000, limit_real_time: realtime + 0.0011)
+                end
             end
         end
 
-        describe "#deregister" do
-            it "removes the streams that are managed by the deployment task from the aligner" do
-                deployment_task = deployment_m.new
-                subject.register(deployment_task)
-                flexmock(subject.stream_aligner)
-                    .should_receive(:remove_streams)
-                    .with(streams.find_port_by_name("out"))
-                    .once
-                subject.deregister(deployment_task)
-            end
-            it "does not deregister streams that are still in use by another deployment" do
-                deployment_task = deployment_m.new
-                subject.register(deployment_task)
-                other_task = deployment_m.new
-                subject.register(other_task)
-
-                flexmock(subject.stream_aligner)
-                    .should_receive(:remove_streams)
-                    .with().once.pass_thru
-                subject.deregister(other_task)
-            end
-            it "deregisters the deployment task from the targets for the stream" do
-                deployment_task = deployment_m.new
-                subject.register(deployment_task)
-                other_task = deployment_m.new
-                subject.register(other_task)
-                subject.deregister(other_task)
-                assert_equal [deployment_task],
-                             subject.find_deployments_of_stream(port_stream)
-            end
-            it "deregisters the stream if no deployment tasks are still using it" do
-                deployment_task = deployment_m.new
-                subject.register(deployment_task)
-                subject.deregister(deployment_task)
-                assert_equal [], subject.find_deployments_of_stream(port_stream)
-            end
-        end
-
-        describe "realtime replay" do
-            it "raises RuntimeError in #start if it is already running" do
-                subject.start
-                assert_raises(RuntimeError) { subject.start }
-            end
-
-            it "is running after a call to #start" do
-                subject.start
-                assert subject.running?
-            end
-
-            it "raises RuntimeError if #stop is called while it is not running" do
-                assert_raises(RuntimeError) { subject.stop }
-            end
-
-            it "is not running after a call to #stop" do
-                subject.start
-                subject.stop
-                assert !subject.running?
-            end
-
-            it "installs a handler that calls #process_in_realtime once in each cycle" do
-                subject.execution_engine.execute_one_cycle
-                subject.start(replay_speed: 10)
-                flexmock(subject).should_receive(:process_in_realtime).twice.with(10)
-                subject.execution_engine.execute_one_cycle
-                subject.execution_engine.execute_one_cycle
-                subject.stop
-                subject.execution_engine.execute_one_cycle
-            end
-        end
-
-        describe "#process_in_realtime" do
+        describe "from_dir" do
             before do
-                double_t = Roby.app.default_loader.registry.get "/double"
-
-                create_logfile "test.0.log" do
-                    stream0 = create_logfile_stream(
-                        "/port0",
-                        type: double_t,
-                        metadata: { "rock_task_name" => "task",
-                                    "rock_task_object_name" => "out",
-                                    "rock_stream_type" => "port" }
-                    )
-                    stream0.write Time.at(0), Time.at(0), 0
-                    stream0.write Time.at(0), Time.at(1), 1
-                    stream0.write Time.at(0), Time.at(2), 2
-                end
-
-                streams = Streams.from_dir(logfile_pathname)
-                                 .find_task_by_name("task")
-                task_m = Syskit::TaskContext.new_submodel do
-                    output_port "out", double_t
-                end
-
-                deployment_m = Syskit::Log::Deployment
-                               .for_streams(streams, model: task_m, name: "task")
-                deployment = deployment_m.new(process_name: "test", on: "pocolog")
-                plan.add_permanent_task(deployment)
-                expect_execution { deployment.start! }
-                    .to { emit deployment.ready_event }
-
-                @subject = plan.execution_engine.pocolog_replay_manager
-                subject.reset_replay_base_times
-                flexmock(subject)
+                @streams = Streams.from_dir(logfile_pathname)
+                                  .find_task_by_name("task")
+                @port_stream = streams.find_port_by_name("out")
+                @deployment_m = Syskit::Log::Deployment
+                                .for_streams(streams, model: task_m, name: "task")
             end
 
-            it "plays as many samples as required to match real and expected logical time" do
-                subject.should_receive(:sleep)
-                realtime = subject.base_real_time
-                flexmock(Time).should_receive(:now).and_return { realtime }
-                subject.should_receive(:dispatch).once.with(0, Time.at(0))
-                       .and_return { realtime += 1 }
-                subject.should_receive(:dispatch).once.with(0, Time.at(1))
-                       .and_return { realtime += 1 }
-                subject.process_in_realtime(1, limit_real_time: realtime + 1.1)
+            common_behavior
+        end
+
+        describe "from_dataset" do
+            before do
+                _, dataset = import_logfiles
+                @streams = Streams.from_dataset(dataset)
+                                  .find_task_by_name("task")
+                @port_stream = streams.find_port_by_name("out")
+                @deployment_m = Syskit::Log::Deployment
+                                .for_streams(streams, model: task_m, name: "task")
             end
 
-            it "applies the speed to the sample limit" do
-                subject.should_receive(:sleep)
-                realtime = subject.base_real_time
-                flexmock(Time).should_receive(:now).and_return { realtime }
-                subject.should_receive(:dispatch).once.with(0, Time.at(0))
-                       .and_return { realtime += 1 }
-                subject.should_receive(:dispatch).once.with(0, Time.at(1))
-                       .and_return { realtime += 1 }
-                subject.process_in_realtime(2, limit_real_time: realtime + 0.55)
-            end
+            common_behavior
+        end
 
-            it "returns true if there are samples left to play" do
-                subject.should_receive(:sleep)
-                realtime = subject.base_real_time
-                flexmock(Time).should_receive(:now).and_return { realtime }
-                assert subject.process_in_realtime(1, limit_real_time: realtime + 1.1)
-            end
+        def resolve_pocolog_stream(stream)
+            return stream unless stream.respond_to?(:syskit_eager_load)
 
-            it "returns false on eof" do
-                subject.should_receive(:sleep)
-                realtime = subject.base_real_time
-                flexmock(Time).should_receive(:now).and_return { realtime }
-                assert !subject.process_in_realtime(1, limit_real_time: realtime + 2.1)
-            end
-
-            it "sleeps between samples" do
-                realtime = subject.base_real_time
-                flexmock(Time).should_receive(:now).and_return { realtime }
-                subject.should_receive(:dispatch).with(0, Time.at(0)).globally.ordered
-                subject.should_receive(:sleep).explicitly.with(1).once.globally.ordered
-                       .and_return { realtime += 1 }
-                subject.should_receive(:dispatch).with(0, Time.at(1)).globally.ordered
-                       .and_return { realtime += 1 }
-                subject.process_in_realtime(1, limit_real_time: realtime + 1.1)
-            end
-
-            it "applies the replay speed to the sleeping times" do
-                realtime = subject.base_real_time
-                flexmock(Time).should_receive(:now).and_return { realtime }
-                subject.should_receive(:dispatch)
-                subject.should_receive(:sleep).explicitly.with(0.5).once.globally.ordered
-                       .and_return { realtime += 0.5 }
-                subject.process_in_realtime(2, limit_real_time: realtime + 0.55)
-            end
-
-            it "does not sleep if the required sleep time is below MIN_TIME_DIFF_TO_SLEEP" do
-                realtime = subject.base_real_time
-                flexmock(Time).should_receive(:now).and_return { realtime }
-                subject.should_receive(:dispatch)
-                subject.should_receive(:sleep).explicitly.never
-                subject.process_in_realtime(1000, limit_real_time: realtime + 0.0011)
-            end
+            stream.syskit_eager_load
         end
     end
 end

--- a/test/replay_manager_test.rb
+++ b/test/replay_manager_test.rb
@@ -37,13 +37,14 @@ module Syskit::Log
                 subject.register(deployment_task)
                 other_task = deployment_m.new
                 subject.register(other_task)
-                assert_equal Hash[port_stream => Set[deployment_task, other_task]],
-                             subject.stream_to_deployment
+                assert_equal [deployment_task, other_task],
+                             subject.find_deployments_of_stream(port_stream)
             end
             it "deregisters the stream if no deployment tasks are still using it" do
                 deployment_task = deployment_m.new
                 subject.register(deployment_task)
-                assert_equal Hash[port_stream => Set[deployment_task]], subject.stream_to_deployment
+                assert_equal [deployment_task],
+                             subject.find_deployments_of_stream(port_stream)
             end
             it "aligns the streams that are managed by the deployment task" do
                 deployment_task = deployment_m.new
@@ -93,13 +94,14 @@ module Syskit::Log
                 other_task = deployment_m.new
                 subject.register(other_task)
                 subject.deregister(other_task)
-                assert_equal Hash[port_stream => Set[deployment_task]], subject.stream_to_deployment
+                assert_equal [deployment_task],
+                             subject.find_deployments_of_stream(port_stream)
             end
             it "deregisters the stream if no deployment tasks are still using it" do
                 deployment_task = deployment_m.new
                 subject.register(deployment_task)
                 subject.deregister(deployment_task)
-                assert_equal Hash[], subject.stream_to_deployment
+                assert_equal [], subject.find_deployments_of_stream(port_stream)
             end
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,9 @@ require "syskit/log"
 require "pocolog"
 require "pocolog/test_helpers"
 require "minitest/autorun"
+
 require "syskit/log/datastore/index_build"
+require "syskit/log/datastore/import"
 
 module Syskit::Log
     module Test
@@ -94,6 +96,17 @@ module Syskit::Log
             Datastore::IndexBuild.rebuild(store, set)
 
             [store, set]
+        end
+
+        def import_logfiles(path = logfile_pathname)
+            root_path = make_tmppath
+            datastore_path = root_path + "datastore"
+            datastore_path.mkpath
+            datastore = Datastore.create(datastore_path)
+
+            import = Datastore::Import.new(datastore)
+            dataset = import.import([path])
+            [datastore, dataset]
         end
     end
 end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/tools-pocolog/pull/35

On top of #24 

When looking for data in a dataset, the Dataset object returns a LazyDataStream, which
contains essential information about the data stream, but no actual data. This speeds up
dataset loading (and memory usage) in the very common case of having to use a few
streams. This is rather obviously critical for compressed datasets, since we won't have
to decompress everything to use a single stream (something that would ... invalidate the
whole idea of a compressed dataset in the first place)

This commit modifies the replay manager to be compatible with lazy streams, which it was
not. The replay manager is not yet 100% functional, but this bit is critical to finish the rest of
the compressed dataset support.

