### PR TITLE
chore: refactor to simplify (on top of #25)

### DIFF
--- a/lib/syskit/log/cli/datastore.rb
+++ b/lib/syskit/log/cli/datastore.rb
@@ -247,10 +247,12 @@ module Syskit::Log
                     include:, delete_input: false, compress: false
                 )
                     datastore.in_incoming(keep: delete_input) do |core_path, cache_path|
-                        importer = Syskit::Log::Datastore::Import.new(datastore)
+                        importer =
+                            Syskit::Log::Datastore::Import
+                            .new(datastore, reporter: reporter)
                         dataset = importer.normalize_dataset(
                             paths, core_path,
-                            cache_path: cache_path, reporter: reporter,
+                            cache_path: cache_path,
                             include: include, delete_input: delete_input,
                             compress: compress
                         )
@@ -267,7 +269,7 @@ module Syskit::Log
 
                         begin
                             importer.validate_dataset_import(
-                                dataset, force: options[:force], reporter: reporter
+                                dataset, force: options[:force]
                             )
                         rescue Syskit::Log::Datastore::Import::DatasetAlreadyExists
                             reporter.info(

--- a/lib/syskit/log/cli/datastore.rb
+++ b/lib/syskit/log/cli/datastore.rb
@@ -242,7 +242,7 @@ module Syskit::Log
                     paths
                 end
 
-                def import_dataset( # rubocop:disable Metrics/ParameterLists
+                def import_dataset(
                     paths, reporter, datastore, metadata,
                     include:, delete_input: false, compress: false
                 )

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -6,8 +6,13 @@ require "syskit/log/datastore/normalize"
 
 module Syskit::Log
     class Datastore
-        def self.import(datastore, dataset_path, silent: false, force: false)
-            Import.new(datastore).import(dataset_path, silent: silent, force: force)
+        def self.import(
+            datastore, dataset_path,
+            silent: false, force: false,
+            reporter: Pocolog::CLI::NullReporter.new
+        )
+            Import.new(datastore, reporter: reporter)
+                  .import(dataset_path, silent: silent, force: force)
         end
 
         # Import dataset(s) in a datastore
@@ -17,8 +22,22 @@ module Syskit::Log
             BASENAME_IMPORT_TAG = ".syskit-pocolog-import"
 
             attr_reader :datastore
-            def initialize(datastore)
+
+            def initialize(
+                datastore, output_path,
+                cache_path: output_path, compress: false,
+                reporter: Pocolog::CLI::NullReporter.new
+            )
                 @datastore = datastore
+                @reporter = reporter
+
+                @output_path = output_path
+                @cache_path = cache_path
+                @compress = compress
+            end
+
+            def compress?
+                @compress
             end
 
             # Compute the information about what will need to be done during the
@@ -52,18 +71,16 @@ module Syskit::Log
             # @return [Pathname] the directory of the imported dataset in the store
             def import(
                 in_dataset_paths,
-                force: false, reporter: Pocolog::CLI::NullReporter.new,
+                force: false,
                 include: IMPORT_DEFAULT_STEPS, delete_input: false
             )
                 datastore.in_incoming(keep: delete_input) do |core_path, cache_path|
                     dataset = normalize_dataset(
                         in_dataset_paths, core_path,
-                        cache_path: cache_path, reporter: reporter, include: include,
+                        cache_path: cache_path, include: include,
                         delete_input: delete_input
                     )
-                    validate_dataset_import(
-                        dataset, force: force, reporter: reporter
-                    )
+                    validate_dataset_import(dataset, force: force)
                     move_dataset_to_store(dataset)
                 end
             end
@@ -96,13 +113,8 @@ module Syskit::Log
             # @param [Pathname] dir_path the imported directory
             # @param [Dataset] dataset the normalized dataset, ready to be moved in
             #   the store
-            # @param [Boolean] force if force (the default), the method will fail if
-            #   the dataset is already in the store. Otherwise, it will erase the
-            #   existing dataset with the new one
             # @return [Dataset] the dataset at its final place
-            # @raise DatasetAlreadyExists if a dataset already exists with the same
-            #   ID than the new one and 'force' is false
-            def move_dataset_to_store(dataset)
+            def self.move_dataset_to_store(dataset, datastore)
                 dataset_digest = dataset.digest
                 final_core_dir = datastore.core_path_of(dataset_digest)
                 FileUtils.mv dataset.dataset_path, final_core_dir
@@ -119,14 +131,12 @@ module Syskit::Log
             # @api private
             #
             # Verifies that the given data should be imported
-            def validate_dataset_import(
-                dataset, force: false, reporter: Pocolog::CLI::NullReporter.new
-            )
+            def validate_dataset_import(dataset, force: false)
                 return unless datastore.has?(dataset.digest)
 
                 if force
                     datastore.delete(dataset.digest)
-                    reporter.warn "Replacing existing dataset #{dataset.digest} "\
+                    @reporter.warn "Replacing existing dataset #{dataset.digest} "\
                                   "with new one"
                     return
                 end
@@ -160,84 +170,61 @@ module Syskit::Log
             # It does not import the result into the store
             #
             # @param [Pathname] dir_path the input directory
-            # @param [Pathname] output_dir_path the output directory
             # @return [Dataset] the resulting dataset
             def normalize_dataset(
-                dir_paths, output_dir_path,
-                cache_path: output_dir_path, reporter: CLI::NullReporter.new,
-                include: IMPORT_DEFAULT_STEPS, delete_input: false,
-                compress: false
+                dir_paths, include: IMPORT_DEFAULT_STEPS, delete_input: false
             )
                 pocolog_files, text_files, roby_event_logs, ignored_entries =
                     dir_paths.map { |dir| prepare_import(dir) }
                              .transpose.map(&:flatten)
 
                 if include.include?(:pocolog)
-                    reporter.info "Normalizing pocolog log files"
-                    normalize_pocolog_files(
-                        output_dir_path, pocolog_files,
-                        cache_path: cache_path, reporter: reporter,
-                        delete_input: delete_input, compress: compress
-                    )
+                    @reporter.info "Normalizing pocolog log files"
+                    normalize_pocolog_files(pocolog_files, delete_input: delete_input)
                 end
 
                 if include.include?(:roby)
-                    reporter.info "Copying the Roby event logs"
-                    normalize_roby_logs(
-                        roby_event_logs, output_dir_path,
-                        cache_path: cache_path, reporter: reporter
-                    )
+                    @reporter.info "Copying the Roby event logs"
+                    normalize_roby_logs(roby_event_logs)
                 elsif include.include?(:roby_no_index)
                     roby_event_logs.each do |log|
-                        copy_roby_event_log_no_index(
-                            output_dir_path, log, reporter: reporter
-                        )
+                        copy_roby_event_log_no_index(log)
                     end
                 end
 
                 if include.include?(:text)
-                    reporter.info "Copying #{text_files.size} text files"
-                    copy_text_files(output_dir_path, text_files)
+                    @reporter.info "Copying #{text_files.size} text files"
+                    copy_text_files(text_files)
                 end
 
                 if include.include?(:ignored)
-                    reporter.info "Copying #{ignored_entries.size} remaining "\
+                    @reporter.info "Copying #{ignored_entries.size} remaining "\
                                 "files and folders"
-                    copy_ignored_entries(output_dir_path, ignored_entries)
+                    copy_ignored_entries(ignored_entries)
                 end
 
-                import_generate_identity(
-                    dir_paths, output_dir_path, cache_path: cache_path
-                )
+                import_generate_identity(dir_paths)
             end
 
             # @api private
             #
             # Copy roby logs to the output path while generating a SQL index
-            def normalize_roby_logs(
-                roby_event_logs, output_dir_path, cache_path: output_dir_path,
-                reporter: CLI::NullReporter.new
-            )
-                roby_sql_index = RobySQLIndex::Index.create(cache_path + "roby.sql")
+            def normalize_roby_logs(roby_event_logs)
+                roby_sql_index = RobySQLIndex::Index.create(@cache_path + "roby.sql")
                 roby_event_logs.each do |roby_event_log|
-                    copy_roby_event_log(
-                        output_dir_path, roby_event_log, roby_sql_index,
-                        cache_path: cache_path, reporter: reporter
-                    )
+                    copy_roby_event_log(roby_event_log, roby_sql_index)
                 rescue TypeError, RuntimeError => e
-                    reporter.error "Failed to create index from Roby log file"
-                    reporter.error "The log file will still be part of the dataset. "\
+                    @reporter.error "Failed to create index from Roby log file"
+                    @reporter.error "The log file will still be part of the dataset. "\
                                     "You may attempt to re-create the cached version "\
                                     "later once what is likely to be a bug is fixed"
                     e.full_message.split("\n").each do |line|
-                        reporter.error line
+                        @reporter.error line
                     end
                     roby_sql_index.close
-                    FileUtils.rm_f cache_path + "roby.sql"
+                    FileUtils.rm_f @cache_path + "roby.sql"
 
-                    copy_roby_event_log_no_index(
-                        output_dir_path, roby_event_log, reporter: reporter
-                    )
+                    copy_roby_event_log_no_index(roby_event_log)
                 end
             end
 
@@ -247,23 +234,18 @@ module Syskit::Log
             #
             # It computes the log file's SHA256 digests
             #
-            # @param [Pathname] output_dir the target directory
             # @param [Array<Pathname>] paths the input pocolog log files
             # @return [Hash<Pathname,Digest::SHA256>] a hash of the log file's
             #   pathname to the file's SHA256 digest. The pathnames are
-            #   relative to output_dir
-            def normalize_pocolog_files(
-                output_dir, files,
-                reporter: CLI::NullReporter.new, cache_path: output_dir,
-                delete_input: false, compress: false
-            )
+            #   relative to the output path given to {#initialize}
+            def normalize_pocolog_files(files, delete_input: false)
                 return {} if files.empty?
 
-                out_pocolog_dir = (output_dir + "pocolog")
+                out_pocolog_dir = (@output_path + "pocolog")
                 out_pocolog_dir.mkpath
-                out_pocolog_cache_dir = (cache_path + "pocolog")
+                out_pocolog_cache_dir = (@cache_path + "pocolog")
                 bytes_total = files.inject(0) { |s, p| s + p.size }
-                reporter.reset_progressbar(
+                @reporter.reset_progressbar(
                     "|:bar| :current_byte/:total_byte :eta (:byte_rate/s)",
                     total: bytes_total
                 )
@@ -271,24 +253,23 @@ module Syskit::Log
                 Syskit::Log::Datastore.normalize(
                     files,
                     output_path: out_pocolog_dir, index_dir: out_pocolog_cache_dir,
-                    reporter: reporter, compute_sha256: true, delete_input: delete_input,
-                    compress: compress
+                    compute_sha256: true, delete_input: delete_input,
+                    compress: @compress
                 )
             ensure
-                reporter&.finish
+                @reporter.finish
             end
 
             # @api private
             #
             # Copy text files found in the input directory into the dataset
             #
-            # @param [Pathname] output_dir the target directory
             # @param [Array<Pathname>] paths the input text file paths
             # @return [void]
-            def copy_text_files(output_dir, files)
+            def copy_text_files(files)
                 return if files.empty?
 
-                out_text_dir = (output_dir + "text")
+                out_text_dir = (@output_path + "text")
                 out_text_dir.mkpath
                 FileUtils.cp files, out_text_dir
             end
@@ -296,10 +277,8 @@ module Syskit::Log
             # @api private
             #
             # Generate identity and metadata files at the end of an import
-            def import_generate_identity(
-                input_paths, output_dir_path, cache_path: output_dir_path
-            )
-                dataset = Dataset.new(output_dir_path, cache: cache_path)
+            def import_generate_identity(input_paths)
+                dataset = Dataset.new(@output_path, cache: @cache_path)
                 dataset.write_dataset_identity_to_metadata_file
 
                 input_paths.reverse.each do |dir_path|
@@ -320,22 +299,18 @@ module Syskit::Log
             #
             # It computes the log file's SHA256 digests
             #
-            # @param [Pathname] output_dir the target directory
             # @param [Array<Pathname>] paths the input roby log files
             # @param [Log::RobySQLIndex::Index] roby_sql_index the database in
             #   which essential Roby information is stored
             # @return [Hash<Pathname,Digest::SHA256>] a hash of the log file's
             #   pathname to the file's SHA256 digest
-            def copy_roby_event_log(
-                output_dir, event_log_path, roby_sql_index,
-                cache_path: output_dir, reporter: CLI::NullReporter.new
-            )
+            def copy_roby_event_log(event_log_path, roby_sql_index)
                 in_reader, out_path, out_io, digest, in_stat =
-                    prepare_roby_event_log_copy(output_dir, event_log_path)
+                    prepare_roby_event_log_copy(event_log_path)
                 index_path, index_io = create_roby_event_log_index(
-                    out_path, event_log_path, cache_path
+                    out_path, event_log_path
                 )
-                reporter.reset_progressbar(
+                @reporter.reset_progressbar(
                     "#{event_log_path.basename} [:bar]", total: event_log_path.stat.size
                 )
 
@@ -346,7 +321,7 @@ module Syskit::Log
                     valid = copy_roby_event_log_one_cycle(
                         in_reader, out_io, index_io,
                         rebuilder, roby_sql_index, in_stat,
-                        metadata_update, digest, reporter
+                        metadata_update, digest
                     )
                     break unless valid
                 end
@@ -370,10 +345,10 @@ module Syskit::Log
             def copy_roby_event_log_one_cycle( # rubocop:disable Metrics/ParameterLists
                 in_reader, out_io, index_io,
                 rebuilder, roby_sql_index, in_stat,
-                metadata_update, digest, reporter
+                metadata_update, digest
             )
                 pos = in_reader.tell
-                reporter.current = pos
+                @reporter.current = pos
                 chunk = in_reader.read_one_chunk
                 cycle = in_reader.decode_one_chunk(chunk)
 
@@ -384,8 +359,8 @@ module Syskit::Log
                 roby_sql_index.add_one_cycle(metadata_update, rebuilder, cycle)
                 true
             rescue Roby::DRoby::Logfile::TruncatedFileError => e
-                reporter.warn e.message
-                reporter.warn "truncating Roby log file"
+                @reporter.warn e.message
+                @reporter.warn "truncating Roby log file"
                 index_io.rewind
                 Roby::DRoby::Logfile::Index.write_header(
                     index_io, pos, in_stat.mtime
@@ -401,31 +376,27 @@ module Syskit::Log
             #
             # It computes the log file's SHA256 digests
             #
-            # @param [Pathname] output_dir the target directory
             # @param [Array<Pathname>] paths the input roby log files
             # @return [Hash<Pathname,Digest::SHA256>] a hash of the log file's
             #   pathname to the file's SHA256 digest
-            def copy_roby_event_log_no_index(
-                output_dir, event_log_path,
-                reporter: CLI::NullReporter.new
-            )
+            def copy_roby_event_log_no_index(event_log_path)
                 in_reader, out_path, out_io, digest, in_stat =
-                    prepare_roby_event_log_copy(output_dir, event_log_path)
-                reporter.reset_progressbar(
+                    prepare_roby_event_log_copy(event_log_path)
+                @reporter.reset_progressbar(
                     "#{event_log_path.basename} [:bar]", total: event_log_path.stat.size
                 )
 
                 until in_reader.eof?
                     begin
                         pos = in_reader.tell
-                        reporter.current = pos
+                        @reporter.current = pos
                         chunk = in_reader.read_one_chunk
 
                         Roby::DRoby::Logfile.write_entry(out_io, chunk)
                         digest.update(chunk)
                     rescue Roby::DRoby::Logfile::TruncatedFileError => e
-                        reporter.warn e.message
-                        reporter.warn "truncating Roby log file"
+                        @reporter.warn e.message
+                        @reporter.warn "truncating Roby log file"
                         break
                     end
                 end
@@ -443,9 +414,9 @@ module Syskit::Log
             # Initialize the IOs and objects needed for a roby event log copy
             #
             # Helper to both {#copy_roby_event_log} and {#copy_roby_event_log_no_index}
-            def prepare_roby_event_log_copy(output_dir, event_log_path)
+            def prepare_roby_event_log_copy(event_log_path)
                 i = 0
-                i += 1 while (target_path = output_dir + "roby-events.#{i}.log").file?
+                i += 1 while (target_path = @output_path + "roby-events.#{i}.log").file?
 
                 digest = Digest::SHA256.new
 
@@ -468,8 +439,8 @@ module Syskit::Log
             # @api private
             #
             # Create the index file to be filled by {#copy_roby_event_log}
-            def create_roby_event_log_index(out_path, in_stat, cache_path)
-                index_path = cache_path + out_path.basename.sub_ext(".idx")
+            def create_roby_event_log_index(out_path, in_stat)
+                index_path = @cache_path + out_path.basename.sub_ext(".idx")
                 index_io = index_path.open("w")
                 Roby::DRoby::Logfile::Index.write_header(
                     index_io, in_stat.size, in_stat.mtime
@@ -482,15 +453,14 @@ module Syskit::Log
             # Copy the entries in the input directory that are not recognized as a
             # dataset element
             #
-            # @param [Pathname] output_dir the target directory
             # @param [Array<Pathname>] paths the input elements, which can be
             #   pointing to both files and directories. Directories are copied
             #   recursively
             # @return [void]
-            def copy_ignored_entries(output_dir, paths)
+            def copy_ignored_entries(paths)
                 return if paths.empty?
 
-                out_ignored_dir = (output_dir + "ignored")
+                out_ignored_dir = (@output_path + "ignored")
                 out_ignored_dir.mkpath
                 FileUtils.cp_r paths, out_ignored_dir
             end

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -162,7 +162,7 @@ module Syskit::Log
             # @param [Pathname] dir_path the input directory
             # @param [Pathname] output_dir_path the output directory
             # @return [Dataset] the resulting dataset
-            def normalize_dataset( # rubocop:disable Metrics/ParameterLists
+            def normalize_dataset(
                 dir_paths, output_dir_path,
                 cache_path: output_dir_path, reporter: CLI::NullReporter.new,
                 include: IMPORT_DEFAULT_STEPS, delete_input: false,
@@ -252,7 +252,7 @@ module Syskit::Log
             # @return [Hash<Pathname,Digest::SHA256>] a hash of the log file's
             #   pathname to the file's SHA256 digest. The pathnames are
             #   relative to output_dir
-            def normalize_pocolog_files( # rubocop:disable Metrics/ParameterLists
+            def normalize_pocolog_files(
                 output_dir, files,
                 reporter: CLI::NullReporter.new, cache_path: output_dir,
                 delete_input: false, compress: false

--- a/test/datastore/import_test.rb
+++ b/test/datastore/import_test.rb
@@ -15,8 +15,14 @@ module Syskit::Log
                 @datastore_path = root_path + "datastore"
                 datastore_path.mkpath
                 @datastore = Datastore.create(datastore_path)
-                @import = Import.new(datastore)
+
+                @output_path = @root_path + "normalize-out"
+                @cache_path = @root_path + "cache-out"
+                @output_path.mkpath
+                @cache_path.mkpath
+                @import = Import.new(@output_path, cache_path: @cache_path)
             end
+
             after do
                 root_path.rmtree
             end
@@ -69,11 +75,16 @@ module Syskit::Log
                 end
             end
 
-            describe "#import" do
+            describe "#normalize_dataset" do
                 before do
                     create_logfile "test.0.log" do
-                        create_logfile_stream "test",
-                                              metadata: Hash["rock_task_name" => "task0", "rock_task_object_name" => "port"]
+                        create_logfile_stream(
+                            "test",
+                            metadata: {
+                                "rock_task_name" => "task0",
+                                "rock_task_object_name" => "port"
+                            }
+                        )
                     end
                     create_roby_logfile("test-events.log")
                     FileUtils.touch logfile_pathname("test.txt")
@@ -86,75 +97,38 @@ module Syskit::Log
                     Pocolog::CLI::TTYReporter.new("", color: false, progress: false)
                 end
 
-                it "can import an empty folder" do
+                it "normalizes an empty folder" do
                     Dir.mktmpdir do |dir|
-                        import.import([Pathname.new(dir)])
+                        import.normalize_dataset([Pathname.new(dir)])
                     end
                 end
 
-                it "moves the results under the dataset's ID" do
-                    flexmock(Dataset).new_instances.should_receive(:compute_dataset_digest)
-                                     .and_return("ABCDEF")
-                    import_dir = import.import([logfile_pathname]).dataset_path
-                    assert_equal(datastore_path + "core" + "ABCDEF", import_dir)
-                end
-                it "raises if the target dataset ID already exists" do
-                    flexmock(Dataset).new_instances.should_receive(:compute_dataset_digest)
-                                     .and_return("ABCDEF")
-                    (datastore_path + "core" + "ABCDEF").mkpath
-                    assert_raises(Import::DatasetAlreadyExists) do
-                        import.import([logfile_pathname])
-                    end
-                end
-                it "replaces the current dataset by the new one if the ID already exists but 'force' is true" do
-                    digest = "ABCDEF"
-                    flexmock(Dataset)
-                        .new_instances.should_receive(:compute_dataset_digest)
-                        .and_return(digest)
-                    (datastore_path + "core" + digest).mkpath
-                    FileUtils.touch(datastore_path + "core" + digest + "file")
-                    out, = capture_io do
-                        import.import(
-                            [logfile_pathname], reporter: tty_reporter, force: true
-                        )
-                    end
-                    assert_match(/Replacing existing dataset #{digest} with new one/, out)
-                    assert !(datastore_path + digest + "file").exist?
-                end
-                it "reports its progress" do
-                    # This is not really a unit test. It just exercises the code
-                    # path that reports progress, but checks nothing except the lack
-                    # of exceptions
-                    capture_io do
-                        import.import([logfile_pathname])
-                    end
-                end
                 it "normalizes the pocolog logfiles" do
-                    incoming_path = datastore_path + "incoming" + "0"
                     expected_normalize_args = hsh(
-                        output_path: incoming_path + "core" + "pocolog",
-                        index_dir: incoming_path + "cache" + "pocolog"
+                        output_path: @output_path + "pocolog",
+                        index_dir: @cache_path + "pocolog"
                     )
 
                     flexmock(Syskit::Log::Datastore)
                         .should_receive(:normalize)
                         .with([logfile_pathname("test.0.log")], expected_normalize_args)
                         .once.pass_thru
-                    dataset = import.import([logfile_pathname])
+                    dataset = import.normalize_dataset([logfile_pathname])
                     assert (dataset.dataset_path + "pocolog" + "task0::port.0.log").exist?
                 end
+
                 it "copies the text files" do
-                    import_dir = import.import([logfile_pathname]).dataset_path
+                    import_dir = import.normalize_dataset([logfile_pathname]).dataset_path
                     assert logfile_pathname("test.txt").exist?
                     assert (import_dir + "text" + "test.txt").exist?
                 end
                 it "copies the roby log files into roby-events.N.log" do
-                    import_dir = import.import([logfile_pathname]).dataset_path
+                    import_dir = import.normalize_dataset([logfile_pathname]).dataset_path
                     assert logfile_pathname("test-events.log").exist?
                     assert (import_dir + "roby-events.0.log").exist?
                 end
                 it "copies the unrecognized files" do
-                    import_dir = import.import([logfile_pathname]).dataset_path
+                    import_dir = import.normalize_dataset([logfile_pathname]).dataset_path
 
                     assert logfile_pathname("not_recognized_file").exist?
                     assert logfile_pathname("not_recognized_dir").exist?
@@ -169,7 +143,7 @@ module Syskit::Log
                     logfile_pathname("info.yml").open("w") do |io|
                         YAML.dump(roby_metadata, io)
                     end
-                    dataset = import.import([logfile_pathname])
+                    dataset = import.normalize_dataset([logfile_pathname])
                     assert_equal({ "roby:app_name" => Set["test"],
                                    "timestamp" => Set[0] }, dataset.metadata)
                     assert_equal({ "roby:app_name" => Set["test"],
@@ -183,7 +157,7 @@ module Syskit::Log
 
                     imported = nil
                     _out, err = capture_io do
-                        imported = import.import([logfile_pathname])
+                        imported = import.normalize_dataset([logfile_pathname])
                     end
                     assert_match(/failed to load Roby metadata/, err)
                     assert_equal({ "timestamp" => Set[0] }, imported.metadata)
@@ -198,7 +172,7 @@ module Syskit::Log
                                     mtime: mtime
                     imported = nil
                     capture_io do
-                        imported = import.import([logfile_pathname])
+                        imported = import.normalize_dataset([logfile_pathname])
                     end
 
                     log_path = imported.dataset_path + "roby-events.0.log"
@@ -223,7 +197,7 @@ module Syskit::Log
                         .should_receive(:add_one_cycle).and_raise(RuntimeError)
                     imported = nil
                     capture_io do
-                        imported = import.import([logfile_pathname])
+                        imported = import.normalize_dataset([logfile_pathname])
                     end
 
                     log_path = imported.dataset_path + "roby-events.0.log"
@@ -242,7 +216,7 @@ module Syskit::Log
                                     mtime: mtime
                     imported = nil
                     capture_io do
-                        imported = import.import([logfile_pathname])
+                        imported = import.normalize_dataset([logfile_pathname])
                     end
 
                     log_path = imported.dataset_path + "roby-events.0.log"
@@ -254,6 +228,39 @@ module Syskit::Log
 
                     index = Roby::DRoby::Logfile::Index.read(index_path)
                     assert index.valid_for?(log_path)
+                end
+            end
+
+            describe ".move_dataset_to_store" do
+                it "moves the results under the dataset's ID" do
+                    dataset = Dataset.new(
+                        @output_path,
+                        cache: @cache_path, digest: "ABCDEF"
+                    )
+                    dataset = Import.move_dataset_to_store(dataset, @datastore)
+                    assert_equal(
+                        datastore_path + "core" + "ABCDEF",
+                        dataset.dataset_path
+                    )
+                end
+
+                it "raises if the dataset's core and cache paths are the same" do
+                    dataset = Dataset.new(@output_path, digest: "ABCDEF")
+                    e = assert_raises(ArgumentError) do
+                        Import.move_dataset_to_store(dataset, @datastore)
+                    end
+                    assert_match(
+                        /cannot move a dataset that has identical cache and data paths/,
+                        e.message
+                    )
+                end
+
+                it "ignores if the cache path does not exist" do
+                    dataset = Dataset.new(
+                        @output_path,
+                        cache: Pathname("/does/not/exist"), digest: "ABCDEF"
+                    )
+                    Import.move_dataset_to_store(dataset, @datastore)
                 end
             end
 

--- a/test/datastore_test.rb
+++ b/test/datastore_test.rb
@@ -322,7 +322,7 @@ module Syskit::Log
             end
 
             it "handles key: single_value" do
-                datasets = @datastore.find_all(a: "some")
+                datasets = @datastore.find_all({ a: "some" })
                 assert_equal [@ds_e.dataset_path],
                              datasets.map(&:dataset_path).to_a
             end


### PR DESCRIPTION
This pull requests refactors CLI::Datastore and Datastore::Import to simplify the code a bit:

- move global setup out of the method's argument list and into the object (e.g. paths, reporter)
- move the complete dataset-to-datastore logic into CLI::Datastore as it has steps that are very
  specific to the CLI. The "tools" to do the import are still in Import (an import can be done in a
  few lines of code)

This removes the rubocop overrides introduced in a9d2992590b1186018fee8e9d39e7f1adad6918e