### PR TITLE
feat: compute dataset hash during import (on top of #29)

### DIFF
--- a/lib/syskit/log.rb
+++ b/lib/syskit/log.rb
@@ -44,6 +44,8 @@ require "syskit/log/roby_sql_index/accessors"
 
 module Syskit
     module Log # rubocop:disable Style/Documentation
+        NullReporter = Pocolog::CLI::NullReporter
+
         # Returns the paths of the pocolog log files in a given directory
         #
         # The returned paths are sorted in 'pocolog' order, i.e. multi-IO files are
@@ -101,7 +103,7 @@ module Syskit
         #   existing file.
         # @return [Pathname] the path to the decompressed file
         def self.decompressed(
-            in_path, cache_path, force: false, reporter: Pocolog::CLI::NullReporter.new
+            in_path, cache_path, force: false, reporter: NullReporter.new
         )
             return in_path unless in_path.extname == ".zst"
 
@@ -113,9 +115,7 @@ module Syskit
         end
 
         # Decompress a zst-compressed file in a given output
-        def self.decompress(
-            in_path, out_path, reporter: Pocolog::CLI::NullReporter.new
-        )
+        def self.decompress(in_path, out_path, reporter: NullReporter.new)
             out_path.dirname.mkpath
 
             reporter.current = 0

--- a/lib/syskit/log/cli/datastore.rb
+++ b/lib/syskit/log/cli/datastore.rb
@@ -43,7 +43,7 @@ module Syskit::Log
                     **options
                 )
                     if silent
-                        @reporter = Pocolog::CLI::NullReporter.new
+                        @reporter = NullReporter.new
                     else
                         @reporter = Pocolog::CLI::TTYReporter.new(
                             format, progress: progress, colors: colors, **options

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -238,8 +238,7 @@ module Syskit::Log
                 Syskit::Log::Datastore.normalize(
                     files,
                     output_path: out_pocolog_dir, index_dir: out_pocolog_cache_dir,
-                    compute_sha256: true, delete_input: delete_input,
-                    compress: @compress, reporter: @reporter
+                    delete_input: delete_input, compress: @compress, reporter: @reporter
                 )
             ensure
                 @reporter.finish

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -15,8 +15,7 @@ module Syskit::Log
 
             def initialize(
                 output_path,
-                cache_path: output_path, compress: false,
-                reporter: Pocolog::CLI::NullReporter.new
+                cache_path: output_path, compress: false, reporter: NullReporter.new
             )
                 @reporter = reporter
 
@@ -116,8 +115,7 @@ module Syskit::Log
             #
             # Verifies that the given data should be imported
             def self.validate_dataset_import(
-                datastore, dataset,
-                force: false, reporter: Pocolog::CLI::NullReporter.new
+                datastore, dataset, force: false, reporter: NullReporter.new
             )
                 return unless datastore.has?(dataset.digest)
 

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -163,16 +163,19 @@ module Syskit::Log
                     dir_paths.map { |dir| prepare_import(dir) }
                              .transpose.map(&:flatten)
 
+                identity = []
                 if include.include?(:pocolog)
                     @reporter.info "Normalizing pocolog log files"
-                    normalize_pocolog_files(pocolog_files, delete_input: delete_input)
+                    identity += normalize_pocolog_files(
+                        pocolog_files, delete_input: delete_input
+                    )
                 end
 
                 if include.include?(:roby)
                     @reporter.info "Copying the Roby event logs"
-                    normalize_roby_logs(roby_event_logs)
+                    identity += normalize_roby_logs(roby_event_logs)
                 elsif include.include?(:roby_no_index)
-                    roby_event_logs.each do |log|
+                    identity += roby_event_logs.map do |log|
                         copy_roby_event_log_no_index(log)
                     end
                 end
@@ -188,7 +191,7 @@ module Syskit::Log
                     copy_ignored_entries(ignored_entries)
                 end
 
-                import_generate_identity(dir_paths)
+                import_generate_identity(dir_paths, identity)
             end
 
             # @api private
@@ -196,7 +199,7 @@ module Syskit::Log
             # Copy roby logs to the output path while generating a SQL index
             def normalize_roby_logs(roby_event_logs)
                 roby_sql_index = RobySQLIndex::Index.create(@cache_path + "roby.sql")
-                roby_event_logs.each do |roby_event_log|
+                roby_event_logs.map do |roby_event_log|
                     copy_roby_event_log(roby_event_log, roby_sql_index)
                 rescue TypeError, RuntimeError => e
                     @reporter.error "Failed to create index from Roby log file"
@@ -220,11 +223,10 @@ module Syskit::Log
             # It computes the log file's SHA256 digests
             #
             # @param [Array<Pathname>] paths the input pocolog log files
-            # @return [Hash<Pathname,Digest::SHA256>] a hash of the log file's
-            #   pathname to the file's SHA256 digest. The pathnames are
-            #   relative to the output path given to {#initialize}
+            # @return [[Dataset::IdentityEntry]] information needed to compute
+            #   the dataset identity
             def normalize_pocolog_files(files, delete_input: false)
-                return {} if files.empty?
+                return [] if files.empty?
 
                 out_pocolog_dir = (@output_path + "pocolog")
                 out_pocolog_dir.mkpath
@@ -261,9 +263,9 @@ module Syskit::Log
             # @api private
             #
             # Generate identity and metadata files at the end of an import
-            def import_generate_identity(input_paths)
+            def import_generate_identity(input_paths, identity)
                 dataset = Dataset.new(@output_path, cache: @cache_path)
-                dataset.write_dataset_identity_to_metadata_file
+                dataset.write_dataset_identity_to_metadata_file(identity)
 
                 input_paths.reverse.each do |dir_path|
                     roby_info_yml_path = (dir_path + "info.yml")
@@ -312,9 +314,12 @@ module Syskit::Log
                     break unless valid
                 end
 
+                entry = Dataset::IdentityEntry.new(
+                    out_path, out_io.tell, out_io.string_digest
+                )
                 out_io.close
                 FileUtils.touch out_path.to_s, mtime: in_stat.mtime
-                { out_path => out_io.digest }
+                entry
             rescue StandardError
                 out_path&.unlink
                 index_path&.unlink
@@ -366,8 +371,8 @@ module Syskit::Log
             # It computes the log file's SHA256 digests
             #
             # @param [Array<Pathname>] paths the input roby log files
-            # @return [Hash<Pathname,Digest::SHA256>] a hash of the log file's
-            #   pathname to the file's SHA256 digest
+            # @return [Dataset::IdentityEntry] the file's identity as used by the
+            #   dataset to identity itself
             def copy_roby_event_log_no_index(event_log_path)
                 in_reader, out_path, out_io, in_stat =
                     prepare_roby_event_log_copy(event_log_path)
@@ -389,9 +394,12 @@ module Syskit::Log
                     end
                 end
 
+                entry = Dataset::IdentityEntry.new(
+                    out_path, out_io.tell, out_io.string_digest
+                )
                 out_io.close
                 FileUtils.touch out_path.to_s, mtime: in_stat.mtime
-                { out_path => out_io.digest }
+                entry
             ensure
                 in_reader&.close
                 out_io&.close unless out_io&.closed?

--- a/lib/syskit/log/datastore/index_build.rb
+++ b/lib/syskit/log/datastore/index_build.rb
@@ -5,7 +5,7 @@ require "roby/droby/logfile/index"
 module Syskit::Log
     class Datastore
         def self.index_build(datastore, dataset,
-            force: false, reporter: Pocolog::CLI::NullReporter.new)
+            force: false, reporter: NullReporter.new)
             IndexBuild.new(datastore, dataset)
                       .rebuild(force: force, reporter: reporter)
         end
@@ -26,14 +26,14 @@ module Syskit::Log
             end
 
             # Rebuild this dataset's indexes
-            def rebuild(force: false, reporter: Pocolog::CLI::NullReporter.new)
+            def rebuild(force: false, reporter: NullReporter.new)
                 rebuild_pocolog_indexes(force: force, reporter: reporter)
                 rebuild_roby_index(force: force, reporter: reporter)
             end
 
             # Rebuild this dataset's indexes
             def self.rebuild(
-                datastore, dataset, force: false, reporter: Pocolog::CLI::NullReporter.new
+                datastore, dataset, force: false, reporter: NullReporter.new
             )
                 new(datastore, dataset).rebuild(force: force, reporter: reporter)
             end
@@ -43,9 +43,7 @@ module Syskit::Log
             # @param [Boolean] force if true, the indexes will all be rebuilt.
             #   Otherwise, only the indexes that do not seem to be up-to-date
             #   will.
-            def rebuild_pocolog_indexes(
-                force: false, reporter: Pocolog::CLI::NullReporter.new
-            )
+            def rebuild_pocolog_indexes(force: false, reporter: NullReporter.new)
                 pocolog_index_dir = (dataset.cache_path + "pocolog")
                 pocolog_index_dir.mkpath
                 if force
@@ -77,7 +75,7 @@ module Syskit::Log
             end
 
             # Rebuild the dataset's Roby index
-            def rebuild_roby_index(force: false, reporter: Pocolog::CLI::NullReporter.new)
+            def rebuild_roby_index(force: false, reporter: NullReporter.new)
                 dataset.cache_path.mkpath
                 event_logs = Syskit::Log.logfiles_in_dir(dataset.dataset_path)
                 event_logs = event_logs.find_all do |roby_log_path|
@@ -96,7 +94,7 @@ module Syskit::Log
             # @return [Boolean] true if the log file is valid and has a valid index,
             #   false otherwise (e.g. if the log file format is too old)
             def rebuild_roby_own_index(
-                roby_log_path, force: false, reporter: Pocolog::CLI::NullReporter.new
+                roby_log_path, force: false, reporter: NullReporter.new
             )
                 roby_index_path = dataset.roby_index_path(roby_log_path)
                 needs_rebuild =
@@ -126,7 +124,7 @@ module Syskit::Log
             #
             # Rebuild the Roby SQL index
             def rebuild_roby_sql_index(
-                roby_log_paths, force: false, reporter: Pocolog::CLI::NullReporter.new
+                roby_log_paths, force: false, reporter: NullReporter.new
             )
                 roby_index_path = dataset.cache_path + "roby.sql"
                 if roby_index_path.exist?

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -6,8 +6,7 @@ module Syskit::Log
     class Datastore
         def self.normalize(
             paths,
-            output_path: paths.first.dirname + "normalized",
-            reporter: Pocolog::CLI::NullReporter.new,
+            output_path: paths.first.dirname + "normalized", reporter: NullReporter.new,
             compute_sha256: false, index_dir: output_path, delete_input: false,
             compress: false
         )
@@ -103,7 +102,7 @@ module Syskit::Log
             def normalize(
                 paths,
                 output_path: paths.first.dirname + "normalized",
-                index_dir: output_path, reporter: Pocolog::CLI::NullReporter.new,
+                index_dir: output_path, reporter: NullReporter.new,
                 compute_sha256: false, delete_input: false
             )
                 output_path.mkpath
@@ -132,8 +131,7 @@ module Syskit::Log
 
             def normalize_logfile_group(
                 files,
-                output_path:,
-                index_dir:, reporter: Pocolog::CLI::NullReporter.new,
+                output_path:, index_dir:, reporter: NullReporter.new,
                 compute_sha256: false
             )
                 files.each do |logfile_path|
@@ -238,7 +236,7 @@ module Syskit::Log
             #   have been touched by the call.
             def normalize_logfile(
                 logfile_path, output_path,
-                reporter: Pocolog::CLI::NullReporter.new, compute_sha256: false
+                reporter: NullReporter.new, compute_sha256: false
             )
                 state = NormalizationState.new([], +"", [])
 

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -7,14 +7,13 @@ module Syskit::Log
         def self.normalize(
             paths,
             output_path: paths.first.dirname + "normalized", reporter: NullReporter.new,
-            compute_sha256: false, index_dir: output_path, delete_input: false,
+            index_dir: output_path, delete_input: false,
             compress: false
         )
             Normalize.new(compress: compress).normalize(
                 paths,
                 output_path: output_path, reporter: reporter,
-                compute_sha256: compute_sha256, index_dir: index_dir,
-                delete_input: delete_input
+                index_dir: index_dir, delete_input: delete_input
             )
         end
 
@@ -103,7 +102,7 @@ module Syskit::Log
                 paths,
                 output_path: paths.first.dirname + "normalized",
                 index_dir: output_path, reporter: NullReporter.new,
-                compute_sha256: false, delete_input: false
+                delete_input: false
             )
                 output_path.mkpath
                 index_dir.mkpath
@@ -114,31 +113,21 @@ module Syskit::Log
                 result = logfile_groups.values.map do |files|
                     group_result = normalize_logfile_group(
                         files,
-                        output_path: output_path, index_dir: index_dir,
-                        reporter: reporter, compute_sha256: compute_sha256
+                        output_path: output_path, index_dir: index_dir, reporter: reporter
                     )
 
                     files.each(&:unlink) if delete_input
                     group_result
                 end
 
-                if compute_sha256
-                    result.inject { |a, b| a.merge(b) }
-                else
-                    result.flatten
-                end
+                result.inject { |a, b| a.merge(b) }
             end
 
             def normalize_logfile_group(
-                files,
-                output_path:, index_dir:, reporter: NullReporter.new,
-                compute_sha256: false
+                files, output_path:, index_dir:, reporter: NullReporter.new
             )
                 files.each do |logfile_path|
-                    normalize_logfile(
-                        logfile_path, output_path,
-                        reporter: reporter, compute_sha256: compute_sha256
-                    )
+                    normalize_logfile(logfile_path, output_path, reporter: reporter)
                 rescue Exception # rubocop:disable Lint/RescueException
                     reporter.warn(
                         "normalize: exception caught while processing #{logfile_path}"
@@ -150,15 +139,11 @@ module Syskit::Log
                 # index ... it makes little sense to write the index
                 write_pending_pocolog_indexes(index_dir) unless compress?
 
-                if compute_sha256
-                    result = {}
-                    out_files.each_value.map do |output|
-                        result[output.path] = output.digest
-                    end
-                    result
-                else
-                    out_files.each_value.map(&:path)
+                result = {}
+                out_files.each_value.map do |output|
+                    result[output.path] = output.digest
                 end
+                result
             rescue Exception # rubocop:disable Lint/RescueException
                 reporter.warn(
                     "normalize: deleting #{out_files.size} output files and their indexes"
@@ -234,10 +219,7 @@ module Syskit::Log
             # @return [(nil,Array<IO>),(Exception,Array<IO>)] returns a potential
             #   exception that has been raised during processing, and the IOs that
             #   have been touched by the call.
-            def normalize_logfile(
-                logfile_path, output_path,
-                reporter: NullReporter.new, compute_sha256: false
-            )
+            def normalize_logfile(logfile_path, output_path, reporter: NullReporter.new)
                 state = NormalizationState.new([], +"", [])
 
                 in_io = Syskit::Log.open_in_stream(logfile_path)
@@ -247,8 +229,7 @@ module Syskit::Log
 
                 reporter_offset = reporter.current
                 normalize_logfile_process_block_stream(
-                    output_path, state, in_block_stream,
-                    reporter: reporter, compute_sha256: compute_sha256
+                    output_path, state, in_block_stream, reporter: reporter
                 )
             rescue Pocolog::InvalidBlockFound => e
                 reporter.warn "#{logfile_path.basename} looks truncated or contains "\
@@ -261,7 +242,7 @@ module Syskit::Log
             end
 
             def normalize_logfile_process_block_stream(
-                output_path, state, in_block_stream, reporter:, compute_sha256:
+                output_path, state, in_block_stream, reporter:
             )
                 reporter_offset = reporter.current
 
@@ -269,8 +250,7 @@ module Syskit::Log
                 while (block_header = in_block_stream.read_next_block_header)
                     begin
                         normalize_logfile_process_block(
-                            output_path, state, block_header, in_block_stream.read_payload,
-                            compute_sha256: compute_sha256
+                            output_path, state, block_header, in_block_stream.read_payload
                         )
                     rescue InvalidFollowupStream => e
                         raise e, "while processing #{in_block_stream.io.path}: #{e.message}"
@@ -289,7 +269,7 @@ module Syskit::Log
             # Process a single in block and dispatch it into separate
             # normalized logfiles
             def normalize_logfile_process_block(
-                output_path, state, block_header, raw_payload, compute_sha256: false
+                output_path, state, block_header, raw_payload
             )
                 stream_index = block_header.stream_index
 
@@ -304,7 +284,7 @@ module Syskit::Log
                 elsif block_header.kind == Pocolog::STREAM_BLOCK
                     normalize_logfile_process_stream_block(
                         state, output_path, stream_index, block_header.raw_data,
-                        raw_payload, compute_sha256: compute_sha256
+                        raw_payload
                     )
                 else
                     normalize_logfile_process_data_block(
@@ -340,14 +320,12 @@ module Syskit::Log
             # Process a single stream definition block in
             # {#normalize_logfile_process_block}
             def normalize_logfile_process_stream_block(
-                state, output_path, stream_index, raw_data, raw_payload,
-                compute_sha256: false
+                state, output_path, stream_index, raw_data, raw_payload
             )
                 stream_block = Pocolog::BlockStream::StreamBlock.parse(raw_payload)
                 stream_block = normalize_stream_definition(stream_block)
                 output = create_or_reuse_out_io(
-                    output_path, raw_data, stream_block, state.control_blocks,
-                    compute_sha256: compute_sha256
+                    output_path, raw_data, stream_block, state.control_blocks
                 )
                 state.out_io_streams[stream_index] = output
 
@@ -391,8 +369,7 @@ module Syskit::Log
             end
 
             def create_or_reuse_out_io(
-                output_path, raw_header, stream_info, initial_blocks,
-                compute_sha256: false
+                output_path, raw_header, stream_info, initial_blocks
             )
                 basename = Streams.normalized_filename(stream_info.metadata)
                 ext = ".zst" if compress?
@@ -416,8 +393,7 @@ module Syskit::Log
                 raw_payload = stream_info.encode
                 raw_header[4, 4] = [raw_payload.size].pack("V")
                 initialize_out_file(
-                    out_file_path, stream_info, raw_header, raw_payload, initial_blocks,
-                    compute_sha256: compute_sha256
+                    out_file_path, stream_info, raw_header, raw_payload, initial_blocks
                 )
             end
 
@@ -427,16 +403,13 @@ module Syskit::Log
             #
             # @return [Output]
             def initialize_out_file(
-                out_file_path, stream_info, raw_header, raw_payload, initial_blocks,
-                compute_sha256: false
+                out_file_path, stream_info, raw_header, raw_payload, initial_blocks
             )
                 wio = Syskit::Log.open_out_stream(out_file_path)
 
                 Pocolog::Format::Current.write_prologue(wio)
-                if compute_sha256
-                    digest = Digest::SHA256.new
-                    wio = DigestIO.new(wio, digest)
-                end
+                digest = Digest::SHA256.new
+                wio = DigestIO.new(wio, digest)
 
                 output = Output.new(out_file_path, wio, stream_info, digest, wio.tell + initial_blocks.size)
                 output.write initial_blocks

--- a/lib/syskit/log/datastore/repair.rb
+++ b/lib/syskit/log/datastore/repair.rb
@@ -5,8 +5,7 @@ module Syskit::Log
         module Repair # rubocop:disable Style/Documentation
             # Detect problems and perform repair steps on the given dataset
             def self.repair_dataset(
-                datastore, dataset,
-                dry_run: true, reporter: Pocolog::CLI::NullReporter.new
+                datastore, dataset, dry_run: true, reporter: NullReporter.new
             )
                 if dry_run
                     ops = find_all_repair_ops(datastore, dataset)

--- a/lib/syskit/log/roby_sql_index/index.rb
+++ b/lib/syskit/log/roby_sql_index/index.rb
@@ -58,7 +58,7 @@ module Syskit
                 attr_reader :event_propagations
 
                 # Add information from a raw Roby log
-                def add_roby_log(path, reporter: Pocolog::CLI::NullReporter.new)
+                def add_roby_log(path, reporter: NullReporter.new)
                     metadata_update = start_roby_log_import(path.basename.to_s)
 
                     size = path.stat.size

--- a/test/datastore/import_test.rb
+++ b/test/datastore/import_test.rb
@@ -130,7 +130,11 @@ module Syskit::Log
                         dataset.dataset_path + "pocolog" + "task0::port.0.log#{file_ext}"
                     assert expected_file.exist?
                 end
-
+                it "calculates the dataset digest" do
+                    dataset = import.normalize_dataset([logfile_pathname])
+                    identity = dataset.compute_dataset_identity_from_files
+                    assert_equal dataset.digest, dataset.compute_dataset_digest(identity)
+                end
                 it "copies the text files" do
                     import_dir = import.normalize_dataset([logfile_pathname]).dataset_path
                     assert logfile_pathname("test.txt").exist?

--- a/test/datastore/index_build_test.rb
+++ b/test/datastore/index_build_test.rb
@@ -134,7 +134,7 @@ module Syskit::Log
                     (dataset_path + "roby-events.0.log").open("w") do |io|
                         Roby::DRoby::Logfile.write_header(io, version: 0)
                     end
-                    reporter = flexmock(Pocolog::CLI::NullReporter.new)
+                    reporter = flexmock(NullReporter.new)
                     reporter.should_receive(:warn)
                             .with("  roby-events.0.log is in an obsolete "\
                                   "Roby log file format, skipping")

--- a/test/datastore/normalize_test.rb
+++ b/test/datastore/normalize_test.rb
@@ -136,7 +136,8 @@ module Syskit::Log
                         expected = Digest::SHA256.hexdigest(
                             actual_data[Pocolog::Format::Current::PROLOGUE_SIZE..-1]
                         )
-                        assert_equal expected, result[path].hexdigest
+                        entry = result.find { |e| e.path == path }
+                        assert_equal expected, entry.sha2
                     end
                 end
                 it "detects followup streams" do

--- a/test/datastore/normalize_test.rb
+++ b/test/datastore/normalize_test.rb
@@ -129,9 +129,7 @@ module Syskit::Log
                     it "optionally computes the sha256 digest of the generated file, "\
                        "without the prologue" do
                         logfile_pathname("normalized").mkdir
-                        result = normalize.normalize(
-                            [logfile_pathname("file0.0.log")], compute_sha256: true
-                        )
+                        result = normalize.normalize([logfile_pathname("file0.0.log")])
 
                         path = logfile_pathname("normalized", "task0::port.0.log")
                         actual_data = read_logfile("normalized", "task0::port.0.log")

--- a/test/datastore/normalize_test.rb
+++ b/test/datastore/normalize_test.rb
@@ -218,7 +218,7 @@ module Syskit::Log
             describe "#normalize_logfile" do
                 it "skips invalid files" do
                     write_logfile "file0.0.log", "INVALID"
-                    reporter = flexmock(Pocolog::CLI::NullReporter.new)
+                    reporter = flexmock(NullReporter.new)
                     flexmock(reporter).should_receive(:current).and_return(10)
                     ext = ".zst" if compress?
                     reporter
@@ -240,7 +240,7 @@ module Syskit::Log
                     end
                     file0_path = logfile_pathname("file0.0.log")
                     logfile_pathname("normalized").mkpath
-                    reporter = flexmock(Pocolog::CLI::NullReporter.new)
+                    reporter = flexmock(NullReporter.new)
                     flexmock(reporter).should_receive(:current).and_return(10)
                     ext = ".zst" if compress?
                     reporter.should_receive(:warn)


### PR DESCRIPTION
It was always meant to be like that... but was actually not. The file hashes were already computed during
normalization, but were ignored at the end of the importation process.