### PR TITLE
feat: move roby.sql into core/

### DIFF
--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -197,8 +197,11 @@ module Syskit::Log
             # @api private
             #
             # Copy roby logs to the output path while generating a SQL index
+            #
+            # @return [Array<Dataset::IdentityEntry>]
             def normalize_roby_logs(roby_event_logs)
-                roby_sql_index = RobySQLIndex::Index.create(@cache_path + "roby.sql")
+                sql_path = @output_path + "roby.sql"
+                roby_sql_index = RobySQLIndex::Index.create(sql_path)
                 roby_event_logs.map do |roby_event_log|
                     copy_roby_event_log(roby_event_log, roby_sql_index)
                 rescue TypeError, RuntimeError => e
@@ -210,7 +213,7 @@ module Syskit::Log
                         @reporter.error line
                     end
                     roby_sql_index.close
-                    FileUtils.rm_f @cache_path + "roby.sql"
+                    sql_path.unlink
 
                     copy_roby_event_log_no_index(roby_event_log)
                 end
@@ -289,7 +292,7 @@ module Syskit::Log
             # @param [Array<Pathname>] paths the input roby log files
             # @param [Log::RobySQLIndex::Index] roby_sql_index the database in
             #   which essential Roby information is stored
-            # @return [Hash<Pathname,Digest::SHA256>] a hash of the log file's
+            # @return [Dataset::IdentityEntry] a hash of the log file's
             #   pathname to the file's SHA256 digest
             def copy_roby_event_log(event_log_path, roby_sql_index) # rubocop:disable Metrics/CyclomaticComplexity
                 in_reader, out_path, out_io, in_stat =

--- a/test/datastore/import_test.rb
+++ b/test/datastore/import_test.rb
@@ -198,7 +198,7 @@ module Syskit::Log
                     assert_equal mtime, log_path.stat.mtime
                     index_path = imported.cache_path + "roby-events.0.idx"
 
-                    assert (imported.cache_path + "roby.sql").exist?
+                    assert (imported.dataset_path + "roby.sql").exist?
                     assert index_path.exist?
 
                     index = Roby::DRoby::Logfile::Index.read(index_path)
@@ -218,7 +218,7 @@ module Syskit::Log
                     log_path = imported.dataset_path + "roby-events.0.log#{file_ext}"
                     assert_equal mtime, log_path.stat.mtime
 
-                    refute (imported.cache_path + "roby.sql").exist?
+                    refute (imported.dataset_path + "roby.sql").exist?
                     refute (imported.cache_path + "roby-events.0.idx").exist?
                 end
                 it "handles truncated Roby logs" do
@@ -238,7 +238,7 @@ module Syskit::Log
                     assert_equal mtime, log_path.stat.mtime
                     index_path = imported.cache_path + "roby-events.0.idx"
 
-                    assert (imported.cache_path + "roby.sql").exist?
+                    assert (imported.dataset_path + "roby.sql").exist?
 
                     unless compress?
                         assert (imported.cache_path + "roby-events.0.idx").exist?


### PR DESCRIPTION
It is critical, takes a long time to generate and the generation process breaks often. Better save it in core/ to make sure that once generated it can be used.

Moreover, having it in core/ makes sure we can use a dataset right away without any index generation.