### PR TITLE
fix: import metadata when info.yml is compressed

### DIFF
--- a/lib/syskit/log.rb
+++ b/lib/syskit/log.rb
@@ -135,6 +135,17 @@ module Syskit
             end
         end
 
+        # Find an existing file at the given path, or at the compressed version of it
+        #
+        # @param [Pathname] path
+        # @return [Pathname,nil]
+        def self.find_path_plain_or_compressed(path)
+            return path if path.exist?
+
+            compressed_path = path.dirname + "#{path.basename}.zst"
+            compressed_path if compressed_path.exist?
+        end
+
         # Write a file atomically
         #
         # It lets us write into a temporary file and move the file in place on

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -133,7 +133,18 @@ module Syskit::Log
 
             # Import Roby's info.yml information into the dataset metadata
             def import_roby_metadata(dataset, roby_info_yml_path)
-                begin roby_info = YAML.safe_load(roby_info_yml_path.read)
+                info_data =
+                    begin
+                        Syskit::Log.open_in_stream(roby_info_yml_path, &:read)
+                    rescue RuntimeError => e
+                        raise unless /zstd/.match?(e.message)
+
+                        warn "failed to load Roby metadata from #{roby_info_yml_path}"
+                        return
+                    end
+
+                begin
+                    roby_info = YAML.safe_load(info_data)
                 rescue Psych::SyntaxError
                     warn "failed to load Roby metadata from #{roby_info_yml_path}"
                     return
@@ -272,10 +283,12 @@ module Syskit::Log
                 dataset.write_dataset_identity_to_metadata_file(identity)
 
                 input_paths.reverse.each do |dir_path|
-                    roby_info_yml_path = (dir_path + "info.yml")
-                    if roby_info_yml_path.exist?
-                        import_roby_metadata(dataset, roby_info_yml_path)
-                    end
+                    info_yml_path = (dir_path + "info.yml")
+                    info_yml_path =
+                        Syskit::Log.find_path_plain_or_compressed(info_yml_path)
+                    next unless info_yml_path
+
+                    import_roby_metadata(dataset, info_yml_path)
                 end
 
                 dataset.timestamp # computes the timestamp

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -70,7 +70,7 @@ module Syskit::Log
                 info_path = (path + BASENAME_IMPORT_TAG)
                 return unless info_path.exist?
 
-                info = YAML.safe_load(info_path.read, [Time])
+                info = YAML.safe_load(info_path.read, permitted_classes: [Time])
                 [info["digest"], info["time"]]
             end
 

--- a/test/datastore/import_test.rb
+++ b/test/datastore/import_test.rb
@@ -99,10 +99,10 @@ module Syskit::Log
                         )
                     end
                     create_roby_logfile("test-events.log")
-                    FileUtils.touch logfile_pathname("test.txt")
-                    FileUtils.touch logfile_pathname("not_recognized_file")
-                    logfile_pathname("not_recognized_dir").mkpath
-                    FileUtils.touch logfile_pathname("not_recognized_dir", "test")
+                    logfile_pathname("test.txt").write("")
+                    logfile_pathname("not_recognized_file").write("")
+                    logdir_pathname("not_recognized_dir").mkpath
+                    logfile_pathname("not_recognized_dir", "test").write("")
                 end
 
                 def tty_reporter
@@ -138,7 +138,7 @@ module Syskit::Log
                 it "copies the text files" do
                     import_dir = import.normalize_dataset([logfile_pathname]).dataset_path
                     assert logfile_pathname("test.txt").exist?
-                    assert (import_dir + "text" + "test.txt").exist?
+                    assert (import_dir + "text" + "test.txt#{file_ext}").exist?
                 end
                 it "copies the roby log files into roby-events.N.log" do
                     import_dir = import.normalize_dataset([logfile_pathname]).dataset_path
@@ -148,19 +148,20 @@ module Syskit::Log
                 it "copies the unrecognized files" do
                     import_dir = import.normalize_dataset([logfile_pathname]).dataset_path
 
-                    assert logfile_pathname("not_recognized_file").exist?
-                    assert logfile_pathname("not_recognized_dir").exist?
-                    assert logfile_pathname("not_recognized_dir", "test").exist?
-
-                    assert (import_dir + "ignored" + "not_recognized_file").exist?
+                    assert(
+                        (import_dir + "ignored" + "not_recognized_file#{file_ext}")
+                        .exist?
+                    )
                     assert (import_dir + "ignored" + "not_recognized_dir").exist?
-                    assert (import_dir + "ignored" + "not_recognized_dir" + "test").exist?
+                    assert(
+                        import_dir
+                            .join("ignored", "not_recognized_dir", "test#{file_ext}")
+                            .exist?
+                    )
                 end
                 it "imports the Roby metadata" do
                     roby_metadata = Array[Hash["app_name" => "test"]]
-                    logfile_pathname("info.yml").open("w") do |io|
-                        YAML.dump(roby_metadata, io)
-                    end
+                    write_logfile("info.yml", YAML.dump(roby_metadata))
                     dataset = import.normalize_dataset([logfile_pathname])
                     assert_equal({ "roby:app_name" => Set["test"],
                                    "timestamp" => Set[0],

--- a/test/datastore/normalize_test.rb
+++ b/test/datastore/normalize_test.rb
@@ -225,7 +225,7 @@ module Syskit::Log
                         write_logfile_sample base_time + 4, base_time + 40, 4
                     end
                     file0_path = logfile_pathname("file0.0.log")
-                    logfile_pathname("normalized").mkpath
+                    logdir_pathname("normalized").mkpath
                     reporter = flexmock(NullReporter.new)
                     flexmock(reporter).should_receive(:current).and_return(10)
                     ext = ".zst" if compress?
@@ -234,7 +234,7 @@ module Syskit::Log
                             .once
                     normalize.normalize_logfile(
                         file0_path,
-                        logfile_pathname("normalized"), reporter: reporter
+                        logdir_pathname("normalized"), reporter: reporter
                     )
                     stream = open_logfile_stream(
                         ["normalized", "task0::port.0.log"], "task0.port"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -90,9 +90,23 @@ module Syskit::Log
             [store, set]
         end
 
+        # Full path to a directory inside the temporary log dir
+        #
+        # @return [Pathname]
+        def logdir_pathname(*path)
+            Pathname.new(logfile_path(*path))
+        end
+
+        # Full path to a file inside the temporary log dir
+        #
+        # The file name will have a .zst extension if we're testing compressed
+        # datasets (see {#compress?})
+        #
+        # @return [Pathname]
         def logfile_pathname(*path)
             raw = Pathname.new(logfile_path(*path))
-            return raw unless /-events\.log$|\.\d+\.log$/.match?(path.last)
+            return raw if path.empty?
+            return raw if raw.extname == ".idx"
             return raw unless compress?
 
             Pathname.new(logfile_path(*path[0..-2], path.last + ".zst"))


### PR DESCRIPTION
The codepath that was taking care of this was not adapted to compression *and* the tests were never
compressing text files. This commit fixes both. This was the only bug triggered by the updated test suite