### PR TITLE
fix: make `syskit ds repair` recreate the roby SQL log

### DIFF
--- a/lib/syskit/log/datastore/dataset.rb
+++ b/lib/syskit/log/datastore/dataset.rb
@@ -700,10 +700,10 @@ module Syskit::Log
             #
             # @return [Pathname]
             def roby_sql_index_path
-                p = dataset_path + "roby.sql"
+                p = cache_path + "roby.sql"
                 return p if p.exist?
 
-                cache_path + "roby.sql"
+                dataset_path + "roby.sql"
             end
 
             # The Roby SQL index

--- a/lib/syskit/log/datastore/repair.rb
+++ b/lib/syskit/log/datastore/repair.rb
@@ -132,9 +132,9 @@ module Syskit::Log
             # @api private
             #
             # Builds the cache folder for the given dataset
-            class CacheRebuild
+            class RobyCacheRebuild
                 def self.detect(datastore, dataset)
-                    return if datastore.cache_path_of(dataset.digest).exist?
+                    return if dataset.roby_sql_index_path.exist?
 
                     new(datastore, dataset)
                 end
@@ -149,9 +149,9 @@ module Syskit::Log
                 end
 
                 def apply(reporter)
-                    Syskit::Log::Datastore.index_build(
-                        @datastore, @dataset, reporter: reporter
-                    )
+                    index_build =
+                        Syskit::Log::Datastore::IndexBuild.new(@datastore, @dataset)
+                    index_build.rebuild_roby_index(reporter: reporter)
                     @dataset
                 end
             end
@@ -186,7 +186,7 @@ module Syskit::Log
                 AddRobyLogsToIdentity,
 
                 # Must be after everything that repairs the identity
-                CacheRebuild,
+                RobyCacheRebuild,
                 ComputeTimestamp
             ].freeze
         end


### PR DESCRIPTION
While the cache is now built on-demand, the roby SQL log is meant to be part of the core/ folder of the dataset. Make sure `repair` rebuilds it.