### PR TITLE
feat: create an single file export process in the DSL modeled after to_daru_frame

### DIFF
--- a/lib/syskit/log/dsl.rb
+++ b/lib/syskit/log/dsl.rb
@@ -804,7 +804,9 @@ module Syskit
                     samples_of(s, from: interval_start, to: interval_end)
                 end
 
-                builders = streams.map { |s| DSL::AlignmentBuilder.new(s.type) }
+                builders = streams.map do |s|
+                    DSL::AlignmentBuilder.new(s.type, s.metadata)
+                end
                 yield(*builders)
 
                 log_file_streams =

--- a/lib/syskit/log/dsl/alignment_builder.rb
+++ b/lib/syskit/log/dsl/alignment_builder.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Syskit
+    module Log
+        module DSL
+            # Representation of a transformation from a stream that is being aligned
+            # into a processed stream
+            class AlignmentBuilder
+                def initialize(type)
+                    @type = type
+                    @output_streams = {}
+                end
+
+                # @api private
+                #
+                # Helper that resolves a field from the block given to {#add} and {#time}
+                #
+                # @return [ResolvedField]
+                def resolve_output_stream
+                    builder = PathBuilder.new(@type)
+                    builder = yield(builder) if block_given?
+                    OutputStream.new(builder.__name, builder.__path,
+                                     builder.__type,
+                                     builder.__transform)
+                end
+
+                def each_output_stream(&block)
+                    @output_streams.each_value(&block)
+                end
+
+                def process(time, sample)
+                    return enum_for(__method__, time, sample) unless block_given?
+
+                    each_output_stream do |s|
+                        yield [time, s.resolve(time, sample)]
+                    end
+                end
+
+                # Add a stream to the alignment output, optionally transforming the data
+                #
+                # @param [String] the output stream name. It must be unique for a
+                #    complete alignment
+                # @yieldparam [PathBuilder] an object that allows to extract specific
+                #    fields and/or apply transformations before the value gets
+                #    stored in the frame
+                def add(name, &block)
+                    if @output_streams.key?(name)
+                        raise ArgumentError, "there is already a stream called #{name}"
+                    end
+
+                    resolved = resolve_output_stream(&block)
+                    resolved.name = name
+                    @output_streams[resolved.name] = resolved
+                    resolved
+                end
+
+                OutputStream = Struct.new :name, :path, :type, :transform do
+                    def resolve(_time, value)
+                        v = path.resolve(value).first.to_ruby
+                        transform ? transform.call(v) : v
+                    end
+                end
+            end
+        end
+    end
+end

--- a/lib/syskit/log/dsl/export_to_single_file.rb
+++ b/lib/syskit/log/dsl/export_to_single_file.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Syskit
+    module Log
+        module DSL # :nodoc:
+            # Create the output streams to export the given alignment builders
+            #
+            # @param [Pocolog::Logfiles] logfile
+            # @param [Array<AlignmentBuilder>] builders
+            # @return [Array<Array<DataStream>>] per-builder output streams. For a
+            #   given builder, the streams are ordered as the outputs are defined
+            #   in the builder itself ({AlignmentBuilder#each_output_stream})
+            def self.export_to_single_file_create_output_streams(logfile, builders)
+                builders.map do |b|
+                    b.each_output_stream.map do |output_stream|
+                        logfile.create_stream(output_stream.name, output_stream.type)
+                    end
+                end
+            end
+
+            # Create the output streams to export the given alignment builders
+            #
+            # @param [Pocolog::Logfiles] logfile
+            # @param [Array<AlignmentBuilder>] builders
+            # @return [Array<Array<DataStream>>] per-builder output streams. For a
+            #   given builder, the streams are ordered as the outputs are defined
+            #   in the builder itself ({AlignmentBuilder#each_output_stream})
+            def self.export_to_single_file_process(
+                builders, log_file_streams, joint_stream
+            )
+                joint_stream.raw_each do |index, time, raw_sample|
+                    this_builder = builders[index]
+                    this_streams = log_file_streams[index]
+                    this_builder
+                        .process(time, raw_sample)
+                        .each_with_index do |(processed_time, processed_sample), i|
+                            this_streams[i].write(
+                                processed_time, processed_time, processed_sample
+                            )
+                        end
+                end
+            end
+        end
+    end
+end

--- a/lib/syskit/log/dsl/export_to_single_file.rb
+++ b/lib/syskit/log/dsl/export_to_single_file.rb
@@ -13,7 +13,9 @@ module Syskit
             def self.export_to_single_file_create_output_streams(logfile, builders)
                 builders.map do |b|
                     b.each_output_stream.map do |output_stream|
-                        logfile.create_stream(output_stream.name, output_stream.type)
+                        logfile.create_stream(
+                            output_stream.name, output_stream.type, output_stream.metadata
+                        )
                     end
                 end
             end

--- a/lib/syskit/log/dsl/path_builder.rb
+++ b/lib/syskit/log/dsl/path_builder.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "syskit/log"
+require "syskit/log/datastore"
+
+module Syskit
+    module Log
+        module DSL
+            # A dsl-based builder for {Typelib::Path}
+            class PathBuilder < BasicObject
+                def initialize(
+                    type, name = "", path = ::Typelib::Path.new([]),
+                    transform = nil
+                )
+                    @type = type
+                    @name = name
+                    @path = path
+                    @transform = transform
+                end
+
+                def __type
+                    @type
+                end
+
+                def __name
+                    @name
+                end
+
+                def __path
+                    @path
+                end
+
+                def __transform
+                    @transform
+                end
+
+                def __terminal?
+                    @transform ||
+                        @type <= ::Typelib::NumericType ||
+                        @type <= ::Typelib::EnumType
+                end
+
+                def transform(to:, &block)
+                    if @transform
+                        raise ArgumentError, "there is already a transform block"
+                    end
+
+                    ::Syskit::Log::Daru::PathBuilder.new(
+                        to, @name, @path, block, nil
+                    )
+                end
+
+                def respond_to?(m)
+                    if @type <= ::Typelib::CompoundType
+                        @type.has_field?(m)
+                    elsif @type <= ::Typelib::ArrayType ||
+                          @type <= ::Typelib::ContainerType
+                        m == :[]
+                    else
+                        false
+                    end
+                end
+
+                def method_missing(m, *args, **kw) # rubocop:disable Style/MissingRespondToMissing
+                    if __terminal?
+                        super
+                    elsif @type <= ::Typelib::CompoundType
+                        __validate_compound_call(m, args, kw)
+                        __resolve_compound_call(m)
+                    elsif @type <= ::Typelib::ArrayType
+                        __validate_array_call(m, args, kw)
+                        __resolve_sequence_call(args.first)
+                    elsif @type <= ::Typelib::ContainerType
+                        __validate_sequence_call(m, args, kw)
+                        __resolve_sequence_call(args.first)
+                    else
+                        super
+                    end
+                end
+
+                def __resolve_compound_call(field_name)
+                    path = @path.dup
+                    path.push_call(:raw_get, field_name)
+                    ::Syskit::Log::Daru::PathBuilder.new(
+                        @type[field_name], "#{@name}.#{field_name}", path
+                    )
+                end
+
+                def __validate_compound_call(field_name, args, kw)
+                    if !@type.has_field?(field_name)
+                        ::Kernel.raise ::NoMethodError.new(field_name),
+                                       "#{@type.name} has no field named '#{field_name}'"
+                    elsif !args.empty? || !kw.empty?
+                        ::Kernel.raise ::ArgumentError,
+                                       "#{@type.name}.#{field_name} expects no "\
+                                       "arguments, got #{args.size} positional and "\
+                                       "#{kw.size} keyword arguments"
+                    end
+                end
+
+                def __validate_sequence_call(name, args, kw)
+                    if name != :[]
+                        ::Kernel.raise ::NoMethodError.new(name),
+                                       "#{@type.name} only accessor is [], got #{name}"
+                    elsif !kw.empty?
+                        ::Kernel.raise ::ArgumentError,
+                                       "#[] does not accept any keyword arguments"
+                    elsif args.size != 1
+                        ::Kernel.raise ::ArgumentError,
+                                       "expected 1 argument to [], but got #{args}"
+                    elsif !args[0].kind_of?(::Integer)
+                        ::Kernel.raise(
+                            ::TypeError,
+                            "expected a single numeric argument, got #{args[0]}"
+                        )
+                    end
+                end
+
+                def __validate_array_call(name, args, kw)
+                    __validate_sequence_call(name, args, kw)
+
+                    index = args[0]
+                    return if index >= 0 && index < @type.length
+
+                    ::Kernel.raise ::ArgumentError,
+                                   "#{args[0]} out of bounds in an array of "\
+                                   "#{@type.length}"
+                end
+
+                def __resolve_sequence_call(index)
+                    path = @path.dup
+                    path.push_call(:raw_get, index)
+                    ::Syskit::Log::Daru::PathBuilder
+                        .new(@type.deference, "#{@name}[#{index}]", path)
+                end
+            end
+        end
+    end
+end

--- a/lib/syskit/log/dsl/path_builder.rb
+++ b/lib/syskit/log/dsl/path_builder.rb
@@ -40,14 +40,16 @@ module Syskit
                         @type <= ::Typelib::EnumType
                 end
 
+                def __new(type, name, path, transform)
+                    PathBuilder.new(type, name, path, transform)
+                end
+
                 def transform(to:, &block)
                     if @transform
                         raise ArgumentError, "there is already a transform block"
                     end
 
-                    ::Syskit::Log::Daru::PathBuilder.new(
-                        to, @name, @path, block, nil
-                    )
+                    __new(to, @name, @path, block)
                 end
 
                 def respond_to?(m)
@@ -81,9 +83,7 @@ module Syskit
                 def __resolve_compound_call(field_name)
                     path = @path.dup
                     path.push_call(:raw_get, field_name)
-                    ::Syskit::Log::Daru::PathBuilder.new(
-                        @type[field_name], "#{@name}.#{field_name}", path
-                    )
+                    __new(@type[field_name], "#{@name}.#{field_name}", path)
                 end
 
                 def __validate_compound_call(field_name, args, kw)
@@ -130,8 +130,7 @@ module Syskit
                 def __resolve_sequence_call(index)
                     path = @path.dup
                     path.push_call(:raw_get, index)
-                    ::Syskit::Log::Daru::PathBuilder
-                        .new(@type.deference, "#{@name}[#{index}]", path)
+                    __new(@type.deference, "#{@name}[#{index}]", path)
                 end
             end
         end

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -417,6 +417,122 @@ module Syskit
                 end
             end
 
+            describe "#export_to_single_file" do
+                before do
+                    now_nsec = Time.now
+                    now = Time.at(now_nsec.tv_sec, now_nsec.tv_usec)
+
+                    registry = Typelib::CXXRegistry.new
+                    compound_t = registry.create_compound "/C" do |b|
+                        b.d = "/double"
+                        b.i = "/int"
+                    end
+                    create_dataset "exists" do
+                        create_logfile "test.0.log" do
+                            create_logfile_stream(
+                                "test", type: compound_t, metadata: {
+                                    "rock_task_name" => "task_test",
+                                    "rock_task_object_name" => "port_test",
+                                    "rock_stream_type" => "port"
+                                }
+                            )
+                            write_logfile_sample now, now, { d: 0.1, i: 1 }
+                            write_logfile_sample now + 10, now + 1, { d: 0.2, i: 2 }
+                        end
+
+                        create_logfile "test1.0.log" do
+                            create_logfile_stream(
+                                "test", type: compound_t, metadata: {
+                                    "rock_task_name" => "task_test1",
+                                    "rock_task_object_name" => "port_test",
+                                    "rock_stream_type" => "port"
+                                }
+                            )
+                            write_logfile_sample now, now + 0.1, { d: 0.15, i: 3 }
+                            write_logfile_sample now + 10, now + 0.9, { d: 0.25, i: 4 }
+                        end
+                    end
+
+                    @context = make_context
+                    @context.datastore_select @datastore_path
+                    @context.dataset_select
+
+                    @exported_path = @root_path + "output.0.log"
+                end
+
+                it "creates a valid empty file if given no streams at all" do
+                    @context.export_to_single_file(@exported_path) do |f|
+                        f.add_logical_time
+                        f.add(&:d)
+                    end
+
+                    logfile = Pocolog::Logfiles.open(@exported_path.to_s)
+                    assert logfile.each_stream.empty?
+                end
+
+                it "copies a single stream" do
+                    port = @context.task_test_task.port_test_port
+                    @context.export_to_single_file @exported_path, port do |f|
+                        f.add("whole_stream")
+                    end
+
+                    logfile = Pocolog::Logfiles.open(@exported_path.to_s)
+                    stream = logfile.stream("whole_stream")
+                    expected = port.samples.map { |_rt, lg, s| [lg, lg, s] }
+                    assert_equal expected, stream.samples.to_a
+                end
+
+                it "aligns different streams" do
+                    port_a = @context.task_test_task.port_test_port
+                    port_b = @context.task_test1_task.port_test_port
+                    @context.export_to_single_file(
+                        @exported_path, port_a, port_b
+                    ) do |a, b|
+                        a.add("a")
+                        b.add("b")
+                    end
+
+                    logfile = Pocolog::Logfiles.open(@exported_path.to_s)
+                    result = logfile.raw_each.to_a
+                    expected =
+                        (port_a.raw_each.map { |_, time, sample| [0, time, sample] } +
+                         port_b.raw_each.map { |_, time, sample| [1, time, sample] })
+                        .sort_by { |_, time, _| time }
+
+                    assert_equal expected, result
+                end
+
+                it "allows to select subfields" do
+                    port = @context.task_test_task.port_test_port
+                    @context.export_to_single_file @exported_path, port do |f|
+                        f.add("subfield", &:d)
+                    end
+
+                    logfile = Pocolog::Logfiles.open(@exported_path.to_s)
+                    stream = logfile.stream("subfield")
+                    assert_equal "/double", stream.type.name
+                    assert_equal port.samples.map { |_rt, lg, s| [lg, lg, s.d] },
+                                 stream.samples.to_a
+                end
+
+                it "allows to perform arbitrary transformations" do
+                    port = @context.task_test_task.port_test_port
+                    registry = Typelib::CXXRegistry.new
+                    string_t = registry.get("/std/string")
+                    @context.export_to_single_file @exported_path, port do |f|
+                        f.add("transformed") do |s|
+                            s.transform(to: string_t) { |c| c.d.to_s }
+                        end
+                    end
+
+                    logfile = Pocolog::Logfiles.open(@exported_path.to_s)
+                    stream = logfile.stream("transformed")
+                    assert_equal "/std/string", stream.type.name
+                    assert_equal port.samples.map { |_rt, lg, s| [lg, lg, s.d.to_s] },
+                                 stream.samples.to_a
+                end
+            end
+
             def make_context
                 context = Object.new
                 context.extend DSL

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -482,6 +482,17 @@ module Syskit
                     assert_equal expected, stream.samples.to_a
                 end
 
+                it "copies the stream metadata" do
+                    port = @context.task_test_task.port_test_port
+                    @context.export_to_single_file @exported_path, port do |f|
+                        f.add("whole_stream")
+                    end
+
+                    logfile = Pocolog::Logfiles.open(@exported_path.to_s)
+                    stream = logfile.stream("whole_stream")
+                    assert_equal port.metadata, stream.metadata
+                end
+
                 it "aligns different streams" do
                     port_a = @context.task_test_task.port_test_port
                     port_b = @context.task_test1_task.port_test_port


### PR DESCRIPTION
This API is meant to allow to prepare log files that can be used as regression tests / test cases for libraries. As for `to_daru_frame`, one defines output streams based on the dataset's streams, and the method will create a file with these streams (possibly transformed), e.g.

```
export_to_single_file "path/to/file.0.log", some_task.some_port, other_task.other_port do |a, b|
   a.add("pose") # copy the whole stream
   a.add("pose_with_noise") { |s| s.transform { |rbs| ... } } # transform the data before saving it
   b.add("only vector") { |s| s.position } # select a given field
end
```