### PR TITLE
fix: finish report after progressbar

### DIFF
--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -344,6 +344,7 @@ module Syskit::Log
                 in_reader&.close
                 index_io&.close
                 out_io.close if out_io && !out_io.closed?
+                @reporter.finish
             end
 
             # @api private


### PR DESCRIPTION
Add `@report.finish` after roby logs copy so the dataset digest gets printed alone at the last line

Before:
![image](https://github.com/user-attachments/assets/62a7cb2e-31af-4ba1-9ecd-c74d4fdfea6c)

New:
![image](https://github.com/user-attachments/assets/89d4a414-c362-4535-ae5a-5d4ec6ae0d58)
