### PR TITLE
fix: solve deployed model inconsistency

### DIFF
--- a/lib/syskit/log/deployment.rb
+++ b/lib/syskit/log/deployment.rb
@@ -17,10 +17,6 @@ module Syskit::Log
             @stream_to_port = {}
         end
 
-        def deployed_model_by_orogen_model(orogen_model)
-            ReplayTaskContext.model_for(orogen_model.task_model)
-        end
-
         def log_port?(*)
             false
         end

--- a/lib/syskit/log/extensions/deployment_group.rb
+++ b/lib/syskit/log/extensions/deployment_group.rb
@@ -6,9 +6,11 @@ module Syskit::Log
         # replaying tasks
         module DeploymentGroup
             # Expose a given set of streams as a task context in Syskit
+            #
+            # (see Models::ReplayTaskContext#for_streams)
             def use_pocolog_task(
                 streams,
-                name: streams.task_name, model: streams.replay_model,
+                name: streams.task_name, model: streams.model.to_component_model,
                 allow_missing: true, skip_incompatible_types: false,
                 on: "pocolog", process_managers: Syskit.conf
             )

--- a/lib/syskit/log/models/deployment.rb
+++ b/lib/syskit/log/models/deployment.rb
@@ -7,7 +7,9 @@ module Syskit::Log
             # Pocolog deployments only have a single task. This is it
             #
             # @return [Syskit::Models::TaskContext]
-            attr_reader :task_model
+            def task_model
+                @task_model ||= @task_name_to_syskit_model.each_value.first
+            end
 
             # Mappings from streams to ports
             #
@@ -53,10 +55,6 @@ module Syskit::Log
                 orogen_model = submodel.each_orogen_deployed_task_context_model.first
                 return unless orogen_model
 
-                submodel.instance_variable_set(
-                    :@task_model,
-                    Syskit::Log::ReplayTaskContext.model_for(orogen_model.task_model)
-                )
                 submodel.instance_variable_set :@streams_to_port, {}
             end
 

--- a/lib/syskit/log/models/deployment.rb
+++ b/lib/syskit/log/models/deployment.rb
@@ -17,14 +17,18 @@ module Syskit::Log
             attr_reader :streams_to_port
 
             # Define a deployment model that will manage the given streams
+            #
+            # @param [Class<Syskit::Component>] model the task model that is being
+            #   replayed. This is *not* the task model that will be used to replay
             def for_streams(
                 streams,
                 name: streams.task_name,
-                model: streams.replay_model,
+                model: streams.model.to_component_model,
                 allow_missing: true, skip_incompatible_types: false
             )
+                replay_model = Syskit::Log::ReplayTaskContext.for_plain_model(model)
                 deployment_model = new_submodel(name: "Deployment::Pocolog::#{name}") do
-                    task name, model
+                    task name, replay_model
                 end
                 deployment_model.add_streams_from(
                     streams,

--- a/lib/syskit/log/models/replay_task_context.rb
+++ b/lib/syskit/log/models/replay_task_context.rb
@@ -18,6 +18,10 @@ module Syskit
 
                 # Define an replay model for the given existing task model
                 def for_plain_model(plain_model, register: true)
+                    if plain_model <= Syskit::Log::ReplayTaskContext
+                        raise ArgumentError, "#{plain_model} is already a replay model"
+                    end
+
                     if (model = find_model_by_orogen(plain_model.orogen_model))
                         return model
                     end


### PR DESCRIPTION
Tests were passing a plain (actual Syskit::TaskContext) `model` argument to `use_pocolog_task` and `for_streams`, while the code was expecting it to be a replay task (subclass of Syskit::Log::ReplayTaskContext). `Deployment` had two ways to determine what the replay task model was, that would agree by pure chance (because of a bug in Syskit::Deployment)

https://github.com/rock-core/tools-syskit/pull/415 solved that bug. After this change, Syskit::Deployment would always pick up the syskit model used to define a deployment to actually create deployed tasks, removing the bug on which syskit-log relied.

This PR clarifies the purpose of the `model` argument, and makes sure that the task used to create Syskit::Log deployments is always a replay task. In addition, instead of trying to re-guess what the task model is, it actually just picks it up where the information is (change in the definition of `Deployment#task_model`)

This should really have no effect on the usage side. So far, only the tests were explicitly passing the task model to `from_streams`