### PR TITLE
fix: do not escape the sqlite URL when initializing ROM

### DIFF
--- a/lib/syskit/log/roby_sql_index/index.rb
+++ b/lib/syskit/log/roby_sql_index/index.rb
@@ -9,7 +9,7 @@ module Syskit
                 def self.open(path, dataset: nil)
                     raise ArgumentError, "#{path} does not exist" unless path.exist?
 
-                    uri = "sqlite://#{CGI.escape(path.to_s)}"
+                    uri = "sqlite://#{path}"
                     rom = ROM.container(:sql, uri) do |config|
                         Definitions.configure(config)
                     end
@@ -20,7 +20,7 @@ module Syskit
                 def self.create(path, dataset: nil)
                     raise ArgumentError, "#{path} already exists" if path.exist?
 
-                    uri = "sqlite://#{CGI.escape(path.to_s)}"
+                    uri = "sqlite://#{path}"
                     rom = ROM.container(:sql, uri) do |config|
                         Definitions.schema(config)
                         Definitions.configure(config)


### PR DESCRIPTION
It seemed to work with sequel 5.82 but fails with sequel 5.83. Not sure how/why ... So remove the CGI.escape.