### PR TITLE
fix: handling of the progress bar with compressed log data

### DIFF
--- a/lib/syskit/log.rb
+++ b/lib/syskit/log.rb
@@ -78,6 +78,10 @@ module Syskit
             end
         end
 
+        def self.io_disk_size(io)
+            File.stat(io.path).size
+        end
+
         def self.open_out_stream(path, &block)
             return path.open("w", &block) unless path.extname == ".zst"
 

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -248,7 +248,7 @@ module Syskit::Log
                 reporter.warn "#{logfile_path.basename} looks truncated or contains "\
                               "garbage (#{e.message}), stopping processing but keeping "\
                               "the samples processed so far"
-                reporter.current = in_io.size + reporter_offset
+                reporter.current = Syskit::Log.io_disk_size(in_io) + reporter_offset
             ensure
                 state.out_io_streams.each(&:flush)
                 in_block_stream&.close
@@ -316,7 +316,7 @@ module Syskit::Log
             rescue Pocolog::InvalidFile
                 reporter.warn "#{logfile_path.basename} does not seem to be "\
                                 "a valid pocolog file, skipping"
-                reporter.current += in_io.size
+                reporter.current += Syskit::Log.io_disk_size(in_io)
                 nil
             end
 


### PR DESCRIPTION
Whenever we ignore / skip data, the progress bar is updated to reflect this. Both places where this happened was doing it wrong by using ZstdIO#size:

- the progress bar is based on the compressed data size, but ZstdIO#size reports the uncompressed size
- ZstdIO#size fails if the file is not fully read

Change to report the disk size, which resolved both issues.