### PR TITLE
feat: `syskit ds pack` and `syskit ds unpack`

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -8,6 +8,7 @@
     <depend package="rom-sql" />
     <depend package="ruby-sqlite3" />
     <depend package="zstd-ruby" />
+    <depend package="minitar" />
     <depend_optional package="data_processing/daru" />
     <depend_optional package="gui/vega-rb" />
     <depend_optional package="data_processing/rb-gsl" />


### PR DESCRIPTION
`pack` creates a tarball of a dataset, in a predefined format:
- no root folder
- description yaml files are first in the tarball (allowing to read them without downloading the whole tarball)

`unpack` takes one of these and puts it in the datastore, using the metadata inside the file to avoid having to rely on the file name.