### PR TITLE
fix: random test failure due to Tempfile being garbage collected

### DIFF
--- a/test/datastore_test.rb
+++ b/test/datastore_test.rb
@@ -267,12 +267,13 @@ module Syskit::Log
 
         describe ".redirect?" do
             before do
-                @file = Pathname.new(Tempfile.new)
+                @io = Tempfile.new
+                @file = Pathname.new(@io.path)
                 @file.write ""
             end
 
             after do
-                @file.unlink
+                @io.close!
             end
 
             it "returns false if the path does not exist" do


### PR DESCRIPTION
I noticed a (random) test failure where a test would fail and then the file unlink would complain that the file does not exist.

I haven't tried to reproduce/debug the bug, but looking at the code, the following condition can make it happen:

- the file is created in setup via Tempfile.new 
- we get the file path and use it via Pathname
- during the test, the Tempfile object gets garbage collected (since we're not holding a reference to it). This closes and deletes the file
- teardown fails

This commit fixes that bug. Let's see if it solves the overall issue.