### PR TITLE
feat: parallel digest and compression stage during log import

### DIFF
--- a/lib/syskit/log/cli/datastore.rb
+++ b/lib/syskit/log/cli/datastore.rb
@@ -253,14 +253,15 @@ module Syskit::Log
                     paths
                 end
 
-                def import_dataset(
+                def import_dataset( # rubocop:disable Metrics/ParameterLists
                     paths, datastore,
-                    include:, delete_input: false, compress: false
+                    include:, delete_input: false, compress: false, parallel: 1
                 )
                     datastore.in_incoming(keep: delete_input) do |core_path, cache_path|
                         importer = Syskit::Log::Datastore::Import.new(
                             core_path,
-                            cache_path: cache_path, reporter: reporter, compress: compress
+                            cache_path: cache_path, reporter: reporter,
+                            compress: compress, parallel: parallel
                         )
                         dataset = importer.normalize_dataset(
                             paths, include: include, delete_input: delete_input
@@ -561,6 +562,10 @@ module Syskit::Log
             method_option :compress,
                           desc: "compress the resulting dataset",
                           type: :boolean, default: false
+            method_option :parallel,
+                          desc: "use this many cores",
+                          type: :numeric, default: 1
+
             option :rebuild_orogen_models,
                    type: :boolean, default: false,
                    desc: "use this to disable rebuilding orogen models",
@@ -624,7 +629,7 @@ module Syskit::Log
                     dataset = import_dataset(
                         paths, datastore,
                         include: include, delete_input: options[:delete_input],
-                        compress: options[:compress]
+                        compress: options[:compress], parallel: options[:parallel]
                     )
 
                     if dataset

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -219,8 +219,14 @@ module Syskit::Log
             def normalize_roby_logs(roby_event_logs)
                 sql_path = @output_path + "roby.sql"
                 roby_sql_index = RobySQLIndex::Index.create(sql_path)
-                roby_event_logs.map do |roby_event_log|
+                roby_event_logs.filter_map do |roby_event_log|
                     copy_roby_event_log(roby_event_log, roby_sql_index)
+                rescue Roby::DRoby::Logfile::InvalidFileError => e
+                    @reporter.error "Invalid Roby log file, skipping"
+                    e.full_message.split("\n").each do |line|
+                        @reporter.error line
+                    end
+                    nil
                 rescue TypeError, RuntimeError => e
                     @reporter.error "Failed to create index from Roby log file"
                     @reporter.error "The log file will still be part of the dataset. "\

--- a/lib/syskit/log/datastore/import.rb
+++ b/lib/syskit/log/datastore/import.rb
@@ -14,14 +14,20 @@ module Syskit::Log
             BASENAME_IMPORT_TAG = ".syskit-pocolog-import"
 
             def initialize(
-                output_path,
-                cache_path: output_path, compress: false, reporter: NullReporter.new
+                output_path, cache_path: output_path,
+                compress: false, reporter: NullReporter.new, parallel: 1
             )
                 @reporter = reporter
 
                 @output_path = output_path
                 @cache_path = cache_path
                 @compress = compress
+                @executor =
+                    if parallel == 1
+                        Concurrent::ImmediateExecutor.new
+                    else
+                        Concurrent::ThreadPoolExecutor.new(max_threads: parallel - 1)
+                    end
             end
 
             def compress?
@@ -252,7 +258,7 @@ module Syskit::Log
 
                 entries = Syskit::Log::Datastore.normalize(
                     files,
-                    output_path: out_pocolog_dir,
+                    output_path: out_pocolog_dir, executor: @executor,
                     delete_input: delete_input, compress: @compress, reporter: @reporter
                 )
                 entries.each { |e| e.path = identity_path(e.path) }

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -337,7 +337,7 @@ module Syskit::Log
                     end
 
                     group_postprocess = group_output.map do |output_stream|
-                        postprocess_output(async_failure, output_path, output_stream)
+                        postprocess_output(output_path, output_stream)
                     end
                     group_postprocess =
                         Concurrent::Promises
@@ -349,6 +349,7 @@ module Syskit::Log
                         p.rmdir
                         identities
                     end
+                    group_postprocess.on_rejection! { async_failure.set }
                     postprocess << group_postprocess
                 end
 
@@ -358,15 +359,15 @@ module Syskit::Log
             end
 
             # Postprocess a single {Output} normalized by {#normalize_logfile_group}
-            def postprocess_output(async_failure, output_path, output)
+            def postprocess_output(output_path, output)
                 future = Concurrent::Promises.future_on(@executor, output.path) do |path|
-                    subcommand_compute_digest(async_failure, path)
+                    subcommand_compute_digest(path)
                 end
 
                 if compress?
                     compress_future =
                         Concurrent::Promises.future_on(@executor, output.path) do |path|
-                            subcommand_compress_path(async_failure, path)
+                            subcommand_compress_path(path)
                         end
                     future = future.zip(compress_future)
                 end
@@ -389,7 +390,7 @@ module Syskit::Log
                     Dataset::IdentityEntry.new(
                         output_path / final_path_basename, size, digest
                     )
-                end.on_rejection! { async_failure.set }
+                end
             end
 
             # Normalize a group of log files
@@ -404,7 +405,7 @@ module Syskit::Log
                 async_failure, files, output_path:, reporter: NullReporter.new
             )
                 files.each do |logfile_path|
-                    return if async_failure.set?
+                    return if async_failure.set? # rubocop:disable Lint/NonLocalExitFromIterator
 
                     normalize_logfile(logfile_path, output_path, reporter: reporter)
                 rescue Exception # rubocop:disable Lint/RescueException
@@ -445,8 +446,7 @@ module Syskit::Log
             # The compressed file is #{path}.zst. The original path is kept
             #
             # @return [void]
-            def subcommand_compress_path(async_failure, path)
-                r, w = IO.pipe
+            def subcommand_compress_path(path)
                 Open3.popen3(
                     "zstd", "--keep", path.to_s, "-o", "#{path}.zst",
                     "--no-progress"
@@ -470,7 +470,7 @@ module Syskit::Log
             # Compute the sha256 digest of the given file
             #
             # @return [String] the digest
-            def subcommand_compute_digest(async_failure, path)
+            def subcommand_compute_digest(path)
                 Open3.popen2("sha256sum", "-b") do |stdin, stdout, wait_thread|
                     IO.copy_stream(
                         path.to_s, stdin,

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -330,7 +330,11 @@ module Syskit::Log
                         output_path: temp_output_path, reporter: reporter
                     )
 
-                    break if async_failure.set?
+                    if async_failure.set?
+                        # Make sure the promise is waited-on below
+                        postprocess.concat(group_output)
+                        break
+                    end
 
                     group_postprocess = group_output.map do |output_stream|
                         postprocess_output(async_failure, output_path, output_stream)

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -342,9 +342,12 @@ module Syskit::Log
                     group_postprocess =
                         Concurrent::Promises
                         .zip_futures_on(@finalization_executor, *group_postprocess)
-                    group_postprocess.on_fulfillment! do
-                        files.each { _1.unlink } if delete_input
-                        temp_output_path.rmdir
+                    group_postprocess = group_postprocess.then_on(
+                        @finalization_executor, files, temp_output_path
+                    ) do |*identities, f, p|
+                        f.each { _1.unlink } if delete_input
+                        p.rmdir
+                        identities
                     end
                     postprocess << group_postprocess
                 end

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -332,12 +332,22 @@ module Syskit::Log
 
                     break if async_failure.set?
 
-                    group_output.each do
-                        postprocess << postprocess_output(async_failure, output_path, _1)
+                    group_postprocess = group_output.map do |output_stream|
+                        postprocess_output(async_failure, output_path, output_stream)
                     end
+                    group_postprocess =
+                        Concurrent::Promises
+                        .zip_futures_on(@finalization_executor, *group_postprocess)
+                    group_postprocess.on_fulfillment! do
+                        files.each { _1.unlink } if delete_input
+                        temp_output_path.rmdir
+                    end
+                    postprocess << group_postprocess
                 end
 
-                Concurrent::Promises.zip_futures_on(@executor, *postprocess).value!
+                Concurrent::Promises
+                    .zip_futures_on(@finalization_executor, *postprocess)
+                    .value!.flatten
             end
 
             # Postprocess a single {Output} normalized by {#normalize_logfile_group}
@@ -372,7 +382,7 @@ module Syskit::Log
                     Dataset::IdentityEntry.new(
                         output_path / final_path_basename, size, digest
                     )
-                end.on_rejection { async_failure.set }
+                end.on_rejection! { async_failure.set }
             end
 
             # Normalize a group of log files

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -9,9 +9,10 @@ module Syskit::Log
         def self.normalize(
             paths,
             output_path: paths.first.dirname + "normalized", reporter: NullReporter.new,
-            delete_input: false, compress: false
+            delete_input: false, compress: false,
+            executor: Concurrent::ImmediateExecutor.new
         )
-            Normalize.new(compress: compress).normalize(
+            Normalize.new(compress: compress, executor: executor).normalize(
                 paths,
                 output_path: output_path, reporter: reporter, delete_input: delete_input
             )
@@ -91,17 +92,14 @@ module Syskit::Log
                 attr_reader :stream_size
                 attr_reader :stream_block_pos
                 attr_reader :last_data_block_time
-                attr_reader :tell
                 attr_reader :interval_rt
                 attr_reader :interval_lg
-                attr_reader :compressed
-                attr_accessor :size
                 attr_accessor :string_digest
 
                 WRITE_BLOCK_SIZE = 128 * 1024
 
                 def initialize(
-                    path, wio, stream_block, stream_block_pos, compressed
+                    path, wio, stream_block, stream_block_pos
                 )
                     @path = path
                     @wio = wio
@@ -111,9 +109,15 @@ module Syskit::Log
                     @stream_size = 0
                     @interval_rt = []
                     @interval_lg = []
-                    @tell = wio.tell
                     @buffer = "".dup
-                    @compressed = compressed
+                end
+
+                def tell
+                    @wio.tell
+                end
+
+                def size
+                    path.stat.size
                 end
 
                 def write_pocolog_minimal_index
@@ -137,7 +141,6 @@ module Syskit::Log
                 def write(data)
                     if data.size + @buffer.size > WRITE_BLOCK_SIZE
                         @wio.write @buffer + data
-                        @tell += @buffer.size + data.size
                         @buffer.clear
                     else
                         @buffer.concat(data)
@@ -147,7 +150,6 @@ module Syskit::Log
                 def flush
                     @wio.write @buffer unless @buffer.empty?
                     @wio.flush
-                    @tell += @buffer.size
                     @buffer.clear
                 end
 
@@ -289,8 +291,9 @@ module Syskit::Log
                 end
             end
 
-            def initialize(compress: false)
+            def initialize(executor: Concurrent::ImmediateExecutor.new, compress: false)
                 @out_files = {}
+                @executor = executor
                 @compress = compress
             end
 
@@ -309,23 +312,82 @@ module Syskit::Log
                     /\.\d+\.log(?:\.zst)?$/.match(_1.basename.to_s).pre_match
                 end
 
-                result = logfile_groups.map do |key, files|
+                async_failure = Concurrent::Event.new
+
+                groups = logfile_groups.to_a
+                postprocess = []
+                until groups.empty?
+                    key, files = groups.shift
+                    id = groups.size
+
                     reporter.info "Normalizing group #{key}"
-                    group_result = normalize_logfile_group(
-                        files, output_path: output_path, reporter: reporter
+
+                    temp_output_path = output_path / id.to_s
+                    temp_output_path.mkdir
+                    group_output = normalize_logfile_group(
+                        async_failure, files,
+                        output_path: temp_output_path, reporter: reporter
                     )
 
-                    files.each(&:unlink) if delete_input
-                    group_result
+                    break if async_failure.set?
+
+                    group_output.each do
+                        postprocess << postprocess_output(async_failure, output_path, _1)
+                    end
                 end
 
-                result.flatten
+                Concurrent::Promises.zip_futures_on(@executor, *postprocess).value!
             end
 
+            # Postprocess a single {Output} normalized by {#normalize_logfile_group}
+            def postprocess_output(async_failure, output_path, output)
+                future = Concurrent::Promises.future_on(@executor, output.path) do |path|
+                    subcommand_compute_digest(async_failure, path)
+                end
+
+                if compress?
+                    compress_future =
+                        Concurrent::Promises.future_on(@executor, output.path) do |path|
+                            subcommand_compress_path(async_failure, path)
+                        end
+                    future = future.zip(compress_future)
+                end
+
+                path = output.path
+                future.then_on(@executor) do |digest|
+                    size = path.stat.size
+                    final_path_basename =
+                        if compress?
+                            path.unlink
+                            "#{path.basename}.zst"
+                        else
+                            path.basename
+                        end
+
+                    source_path = path.dirname / final_path_basename
+                    FileUtils.mv source_path, output_path
+                    FileUtils.mv path.sub_ext(".idx"), output_path
+
+                    Dataset::IdentityEntry.new(
+                        output_path / final_path_basename, size, digest
+                    )
+                end.on_rejection { async_failure.set }
+            end
+
+            # Normalize a group of log files
+            #
+            # A "group" of log files are all log files from the same logger. They are
+            # expected to be rotations of the same set of streams, and therefore are
+            # being normalized to the same set of log files. In addition, we expect
+            # two different groups to not have overlapping streams
+            #
+            # @return [Array<Output>]
             def normalize_logfile_group(
-                files, output_path:, reporter: NullReporter.new
+                async_failure, files, output_path:, reporter: NullReporter.new
             )
                 files.each do |logfile_path|
+                    return if async_failure.set?
+
                     normalize_logfile(logfile_path, output_path, reporter: reporter)
                 rescue Exception # rubocop:disable Lint/RescueException
                     reporter.warn(
@@ -334,38 +396,11 @@ module Syskit::Log
                     raise
                 end
 
-                futures = out_files.each_value.map do |output|
+                out_files.each_value do |output|
                     output.write_pocolog_minimal_index
                     output.close
-
-                    digest = Concurrent::Promises.future do
-                        subcommand_compute_digest(output.path, reporter)
-                    end
-
-                    if output.compressed
-                        compression = Concurrent::Promises.future do
-                            subcommand_compress_path(output.path, reporter)
-                        end
-                    end
-
-                    [output, [digest, compression]]
                 end
-
-                Concurrent::Promises.zip_futures(*futures.flat_map(&:last).compact).wait!
-                futures.each do |output, (digest, compression)|
-                    output.size = output.path.stat.size
-                    if compression
-                        output.path.unlink
-                        output.path = output.path.dirname / "#{output.path.basename}.zst"
-                    end
-                    output.digest = digest.value
-                end
-
-                out_files.each_value.map do |output|
-                    Dataset::IdentityEntry.new(
-                        output.path, output.size, output.string_digest
-                    )
-                end
+                out_files.values
             rescue Exception # rubocop:disable Lint/RescueException
                 reporter.warn(
                     "normalize: deleting #{out_files.size} output files and their indexes"
@@ -385,26 +420,41 @@ module Syskit::Log
                 Pathname.new(path)
             end
 
-            def subcommand_compress_path(path, reporter)
+            # @api private
+            #
+            # Compress the given file
+            #
+            # The compressed file is #{path}.zst. The original path is kept
+            #
+            # @return [void]
+            def subcommand_compress_path(async_failure, path)
                 r, w = IO.pipe
                 Open3.popen3(
                     "zstd", "-19", "--keep", path.to_s, "-o", "#{path}.zst",
-                    "--no-progress") do |stdin, stdout, stderr, wait_thread|
+                    "--no-progress"
+                ) do |stdin, stdout, stderr, wait_thread|
                     stdin.close
-                    err = Thread.new { stdout.read }
-                    out = Thread.new { stderr.read }
+                    err = Thread.new { stderr.read }
+                    out = Thread.new { stdout.read }
                     err, out = [err, out].map(&:value)
                     status = wait_thread.value
                     unless status.success?
                         raise SubcommandFailed,
-                              "compression of #{path.basename} failed: #{output}"
+                              "compression of #{path.basename} failed: " \
+                              "out=#{out} err=#{err}"
                     end
                 end
+                nil
             end
 
-            def subcommand_compute_digest(path, reporter)
+            # @api private
+            #
+            # Compute the sha256 digest of the given file
+            #
+            # @return [String] the digest
+            def subcommand_compute_digest(async_failure, path)
                 r, w = IO.pipe
-                Open3.popen2("sha256sum", path.to_s) do |stdin, stdout, wait_thread|
+                Open3.popen2("sha256sum", "-b", path.to_s) do |stdin, stdout, wait_thread|
                     stdin.close
                     output = stdout.read
                     status = wait_thread.value
@@ -427,8 +477,7 @@ module Syskit::Log
             end
 
             NormalizationState =
-                Struct
-                .new(:out_io_streams, :control_blocks, :followup_stream_time) do
+                Struct.new(:out_io_streams, :control_blocks, :followup_stream_time) do
                     def report_followup_stream_error(
                         reporter: NullReporter.new, stream_index:, mode:, previous:,
                         current:
@@ -518,8 +567,7 @@ module Syskit::Log
 
             def normalize_logfile_process_block_stream(
                 output_path, state, in_block_stream,
-                progress_position:,
-                reporter: NullReporter.new
+                progress_position:, reporter: NullReporter.new
             )
                 reporter_offset = reporter.current
 
@@ -662,8 +710,7 @@ module Syskit::Log
                 output_path, raw_header, stream_block, initial_blocks
             )
                 basename = Streams.normalized_filename(stream_block.metadata)
-                ext = ".zst" if compress?
-                out_file_path = output_path + "#{basename}.0.log#{ext}"
+                out_file_path = output_path + "#{basename}.0.log"
 
                 # Check if that's already known to us (multi-part
                 # logfile)
@@ -695,23 +742,16 @@ module Syskit::Log
             def initialize_out_file(
                 out_file_path, stream_block, raw_header, raw_payload, initial_blocks
             )
-                out_files_key = out_file_path
-                if out_file_path.extname == ".zst"
-                    out_file_path = out_file_path.sub_ext("")
-                    compressed = true
-                end
                 wio = Syskit::Log.open_out_stream(out_file_path)
 
                 Pocolog::Format::Current.write_prologue(wio)
-                output = Output.new(
-                    out_file_path, wio, stream_block, wio.tell, compressed
-                )
+                output = Output.new(out_file_path, wio, stream_block, wio.tell)
                 output.write initial_blocks
                 output.write raw_header[0, 2]
                 output.write ZERO_BYTE
                 output.write raw_header[4..-1]
                 output.write raw_payload
-                out_files[out_files_key] = output
+                out_files[out_file_path] = output
             rescue Exception # rubocop:disable Lint/RescueException
                 wio&.close
                 out_file_path&.unlink if out_file_path&.exist?

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -96,7 +96,7 @@ module Syskit::Log
                 attr_reader :interval_lg
                 attr_accessor :string_digest
 
-                WRITE_BLOCK_SIZE = 128 * 1024
+                WRITE_BLOCK_SIZE = 8 * 1024
 
                 def initialize(
                     path, wio, stream_block, stream_block_pos

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -430,7 +430,7 @@ module Syskit::Log
             def subcommand_compress_path(async_failure, path)
                 r, w = IO.pipe
                 Open3.popen3(
-                    "zstd", "-19", "--keep", path.to_s, "-o", "#{path}.zst",
+                    "zstd", "--keep", path.to_s, "-o", "#{path}.zst",
                     "--no-progress"
                 ) do |stdin, stdout, stderr, wait_thread|
                     stdin.close

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -454,8 +454,12 @@ module Syskit::Log
             #
             # @return [String] the digest
             def subcommand_compute_digest(async_failure, path)
-                r, w = IO.pipe
-                Open3.popen2("sha256sum", "-b", path.to_s) do |stdin, stdout, wait_thread|
+                Open3.popen2("sha256sum", "-b") do |stdin, stdout, wait_thread|
+                    IO.copy_stream(
+                        path.to_s, stdin,
+                        path.stat.size - Pocolog::Format::Current::PROLOGUE_SIZE,
+                        Pocolog::Format::Current::PROLOGUE_SIZE
+                    )
                     stdin.close
                     output = stdout.read
                     status = wait_thread.value

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "digest/sha2"
+require "open3"
 
 module Syskit::Log
     class Datastore
@@ -83,21 +84,24 @@ module Syskit::Log
             #
             # Internal representation of the output of a normalization operation
             class Output
-                attr_reader :path
+                attr_accessor :path
                 attr_reader :logical_time_reader
                 attr_reader :stream_block
-                attr_reader :digest
+                attr_accessor :digest
                 attr_reader :stream_size
                 attr_reader :stream_block_pos
                 attr_reader :last_data_block_time
                 attr_reader :tell
                 attr_reader :interval_rt
                 attr_reader :interval_lg
+                attr_reader :compressed
+                attr_accessor :size
+                attr_accessor :string_digest
 
                 WRITE_BLOCK_SIZE = 128 * 1024
 
                 def initialize(
-                    path, wio, stream_block, digest, stream_block_pos
+                    path, wio, stream_block, stream_block_pos, compressed
                 )
                     @path = path
                     @wio = wio
@@ -107,9 +111,9 @@ module Syskit::Log
                     @stream_size = 0
                     @interval_rt = []
                     @interval_lg = []
-                    @digest = digest
                     @tell = wio.tell
                     @buffer = "".dup
+                    @compressed = compressed
                 end
 
                 def write_pocolog_minimal_index
@@ -283,10 +287,6 @@ module Syskit::Log
                     raise ArgumentError,
                           "no field #{field_name} in #{compound_type}"
                 end
-
-                def string_digest
-                    DatasetIdentity.string_digest(@digest)
-                end
             end
 
             def initialize(compress: false)
@@ -334,19 +334,43 @@ module Syskit::Log
                     raise
                 end
 
-                out_files.each_value.map do |output|
+                futures = out_files.each_value.map do |output|
                     output.write_pocolog_minimal_index
                     output.close
 
+                    digest = Concurrent::Promises.future do
+                        subcommand_compute_digest(output.path, reporter)
+                    end
+
+                    if output.compressed
+                        compression = Concurrent::Promises.future do
+                            subcommand_compress_path(output.path, reporter)
+                        end
+                    end
+
+                    [output, [digest, compression]]
+                end
+
+                Concurrent::Promises.zip_futures(*futures.flat_map(&:last).compact).wait!
+                futures.each do |output, (digest, compression)|
+                    output.size = output.path.stat.size
+                    if compression
+                        output.path.unlink
+                        output.path = output.path.dirname / "#{output.path.basename}.zst"
+                    end
+                    output.digest = digest.value
+                end
+
+                out_files.each_value.map do |output|
                     Dataset::IdentityEntry.new(
-                        output.path, output.tell, output.string_digest
+                        output.path, output.size, output.string_digest
                     )
                 end
             rescue Exception # rubocop:disable Lint/RescueException
                 reporter.warn(
                     "normalize: deleting #{out_files.size} output files and their indexes"
                 )
-                out_files.each_value { _1.path.unlink }
+                out_files.each_value { _1.path.unlink if _1.path.exist? }
                 raise
             ensure
                 out_files.each_value { _1.close unless _1.closed? }
@@ -359,6 +383,38 @@ module Syskit::Log
                     logfile_path, index_dir: index_dir
                 )
                 Pathname.new(path)
+            end
+
+            def subcommand_compress_path(path, reporter)
+                r, w = IO.pipe
+                Open3.popen3(
+                    "zstd", "-19", "--keep", path.to_s, "-o", "#{path}.zst",
+                    "--no-progress") do |stdin, stdout, stderr, wait_thread|
+                    stdin.close
+                    err = Thread.new { stdout.read }
+                    out = Thread.new { stderr.read }
+                    err, out = [err, out].map(&:value)
+                    status = wait_thread.value
+                    unless status.success?
+                        raise SubcommandFailed,
+                              "compression of #{path.basename} failed: #{output}"
+                    end
+                end
+            end
+
+            def subcommand_compute_digest(path, reporter)
+                r, w = IO.pipe
+                Open3.popen2("sha256sum", path.to_s) do |stdin, stdout, wait_thread|
+                    stdin.close
+                    output = stdout.read
+                    status = wait_thread.value
+                    unless status.success?
+                        raise SubcommandFailed,
+                              "digest computation for #{path.basename} " \
+                              "failed: #{output}"
+                    end
+                    output.split(" ").first.strip
+                end
             end
 
             FOLLOWUP_STREAM_TIME_ERROR_FORMAT =
@@ -639,21 +695,23 @@ module Syskit::Log
             def initialize_out_file(
                 out_file_path, stream_block, raw_header, raw_payload, initial_blocks
             )
+                out_files_key = out_file_path
+                if out_file_path.extname == ".zst"
+                    out_file_path = out_file_path.sub_ext("")
+                    compressed = true
+                end
                 wio = Syskit::Log.open_out_stream(out_file_path)
 
                 Pocolog::Format::Current.write_prologue(wio)
-                digest = Digest::SHA256.new
-                wio = DigestIO.new(wio, digest)
-
                 output = Output.new(
-                    out_file_path, wio, stream_block, digest, wio.tell
+                    out_file_path, wio, stream_block, wio.tell, compressed
                 )
                 output.write initial_blocks
                 output.write raw_header[0, 2]
                 output.write ZERO_BYTE
                 output.write raw_header[4..-1]
                 output.write raw_payload
-                out_files[out_file_path] = output
+                out_files[out_files_key] = output
             rescue Exception # rubocop:disable Lint/RescueException
                 wio&.close
                 out_file_path&.unlink if out_file_path&.exist?

--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -294,6 +294,7 @@ module Syskit::Log
             def initialize(executor: Concurrent::ImmediateExecutor.new, compress: false)
                 @out_files = {}
                 @executor = executor
+                @finalization_executor = Concurrent::ImmediateExecutor.new
                 @compress = compress
             end
 
@@ -354,7 +355,7 @@ module Syskit::Log
                 end
 
                 path = output.path
-                future.then_on(@executor) do |digest|
+                future.then_on(@finalization_executor) do |digest|
                     size = path.stat.size
                     final_path_basename =
                         if compress?

--- a/test/datastore/normalize_test.rb
+++ b/test/datastore/normalize_test.rb
@@ -136,21 +136,23 @@ module Syskit::Log
                         )
                         write_logfile_sample base_time + 1, base_time + 30, 3
                     end
-                    reporter = flexmock(NullReporter.new)
+                    reporter = NullReporter.new
                     msg = format(
                         Normalize::FOLLOWUP_STREAM_TIME_ERROR_FORMAT,
-                        stream_name:
-                            logfile_pathname("normalized", "0", "task0::port.0.log"),
+                        stream_name: logfile_pathname(
+                            "normalized", "0", "task0::port.0.log", compress: false
+                        ),
                         mode: "real time",
                         previous: Normalize.format_timestamp(timestamp_us(base_time + 2)),
                         current: Normalize.format_timestamp(timestamp_us(base_time + 1))
                     )
-                    reporter.should_receive(:warn)
-                            .with(msg).once
-                    normalize.normalize(
-                        [logfile_pathname("file0.0.log"),
-                         logfile_pathname("file0.1.log")], reporter: reporter
-                    )
+                    warnings = record_warnings(reporter) do
+                        normalize.normalize(
+                            [logfile_pathname("file0.0.log"),
+                             logfile_pathname("file0.1.log")], reporter: reporter
+                        )
+                    end
+                    assert_includes warnings, msg
                     stream = open_logfile_stream(
                         ["normalized", "task0::port.0.log"], "task0.port"
                     )
@@ -169,22 +171,24 @@ module Syskit::Log
                         )
                         write_logfile_sample base_time + 50, base_time, 3
                     end
-                    reporter = flexmock(NullReporter.new)
+                    reporter = NullReporter.new
                     msg = format(
                         Normalize::FOLLOWUP_STREAM_TIME_ERROR_FORMAT,
-                        stream_name:
-                            logfile_pathname("normalized", "0", "task0::port.0.log"),
+                        stream_name: logfile_pathname(
+                            "normalized", "0", "task0::port.0.log",
+                            compress: false
+                        ),
                         mode: "logical time",
                         previous: Normalize.format_timestamp(timestamp_us(base_time + 20)),
                         current: Normalize.format_timestamp(timestamp_us(base_time))
                     )
-                    reporter.should_receive(:warn)
-                            .with(msg)
-                            .once
-                    normalize.normalize(
-                        [logfile_pathname("file0.0.log"),
-                         logfile_pathname("file0.1.log")], reporter: reporter
-                    )
+                    warnings = record_warnings(reporter) do
+                        normalize.normalize(
+                            [logfile_pathname("file0.0.log"),
+                             logfile_pathname("file0.1.log")], reporter: reporter
+                        )
+                    end
+                    assert_includes warnings, msg
                     stream = open_logfile_stream(
                         ["normalized", "task0::port.0.log"], "task0.port"
                     )
@@ -453,6 +457,15 @@ module Syskit::Log
 
             def timestamp_us(time)
                 time.tv_sec * 1_000_000 + time.tv_usec
+            end
+
+            def record_warnings(reporter)
+                record = []
+                FlexMock.use(reporter) do |mock|
+                    mock.should_receive(:warn).and_return { |args| record << args }
+                    yield
+                end
+                record
             end
         end
     end

--- a/test/datastore/normalize_test.rb
+++ b/test/datastore/normalize_test.rb
@@ -124,7 +124,7 @@ module Syskit::Log
                     assert_equal [[base_time + 2, base_time + 20, 2],
                                   [base_time + 3, base_time + 30, 3]], stream.samples.to_a
                 end
-                it "skips the sample if a potential followup stream has an non-matching "\
+                it "skips the sample if a potential followup stream has a non-matching "\
                    "realtime range" do
                     create_logfile "file0.1.log" do
                         create_logfile_stream(
@@ -139,20 +139,17 @@ module Syskit::Log
                     reporter = flexmock(NullReporter.new)
                     msg = format(
                         Normalize::FOLLOWUP_STREAM_TIME_ERROR_FORMAT,
-                        stream_name: logfile_pathname("normalized", "task0::port.0.log"),
+                        stream_name:
+                            logfile_pathname("normalized", "0", "task0::port.0.log"),
                         mode: "real time",
                         previous: Normalize.format_timestamp(timestamp_us(base_time + 2)),
                         current: Normalize.format_timestamp(timestamp_us(base_time + 1))
                     )
                     reporter.should_receive(:warn)
-                            .with(msg)
-                            .once
+                            .with(msg).once
                     normalize.normalize(
-                        [
-                            logfile_pathname("file0.0.log"),
-                            logfile_pathname("file0.1.log")
-                        ],
-                        reporter: reporter
+                        [logfile_pathname("file0.0.log"),
+                         logfile_pathname("file0.1.log")], reporter: reporter
                     )
                     stream = open_logfile_stream(
                         ["normalized", "task0::port.0.log"], "task0.port"
@@ -160,7 +157,7 @@ module Syskit::Log
                     assert_equal(stream.size, 1)
                     assert_equal(stream[0][2], 2)
                 end
-                it "skips the sample if a potential followup stream has an non-matching "\
+                it "skips the sample if a potential followup stream has a non-matching "\
                    "logical time range" do
                     create_logfile "file0.1.log" do
                         create_logfile_stream(
@@ -175,7 +172,8 @@ module Syskit::Log
                     reporter = flexmock(NullReporter.new)
                     msg = format(
                         Normalize::FOLLOWUP_STREAM_TIME_ERROR_FORMAT,
-                        stream_name: logfile_pathname("normalized", "task0::port.0.log"),
+                        stream_name:
+                            logfile_pathname("normalized", "0", "task0::port.0.log"),
                         mode: "logical time",
                         previous: Normalize.format_timestamp(timestamp_us(base_time + 20)),
                         current: Normalize.format_timestamp(timestamp_us(base_time))
@@ -184,11 +182,8 @@ module Syskit::Log
                             .with(msg)
                             .once
                     normalize.normalize(
-                        [
-                            logfile_pathname("file0.0.log"),
-                            logfile_pathname("file0.1.log")
-                        ],
-                        reporter: reporter
+                        [logfile_pathname("file0.0.log"),
+                         logfile_pathname("file0.1.log")], reporter: reporter
                     )
                     stream = open_logfile_stream(
                         ["normalized", "task0::port.0.log"], "task0.port"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,11 +105,11 @@ module Syskit::Log
         # datasets (see {#compress?})
         #
         # @return [Pathname]
-        def logfile_pathname(*path)
+        def logfile_pathname(*path, compress: compress?)
             raw = Pathname.new(logfile_path(*path))
             return raw if path.empty?
             return raw if raw.extname == ".idx"
-            return raw unless compress?
+            return raw unless compress
 
             Pathname.new(logfile_path(*path[0..-2], path.last + ".zst"))
         end


### PR DESCRIPTION
A significant amount of CPU is spent on digest calculation and on compression (profiling on some of our logs showed around 40%). This PR runs them as separate processes to make both parallel.

In addition to all of that, zstd is stupidly well optimized even on the I/O side, which leads to even more savings on huge logs.