### PR TITLE
fix: process properties first

### DIFF
--- a/lib/syskit/log/datastore/normalize.rb
+++ b/lib/syskit/log/datastore/normalize.rb
@@ -435,7 +435,11 @@ module Syskit::Log
                     /\.\d+\.log(?:\.zst)?$/.match(_1.basename.to_s).pre_match
                 end
 
-                result = logfile_groups.map do |key, files|
+                properties_files = logfile_groups.delete("properties")
+                groups = logfile_groups.to_a
+                groups.unshift(["properties", properties_files]) if properties_files
+
+                result = groups.map do |key, files|
                     reporter.info "Normalizing group #{key}"
                     group_result = normalize_logfile_group(
                         files, output_path: output_path, reporter: reporter


### PR DESCRIPTION
The properties log has an unusual amount of streams, which makes syskit-log hit open file limits. Processing it first makes sure we hit that limit early instead of after an hour or two of processing.